### PR TITLE
Add ForeFlight mode

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -499,6 +499,7 @@ type settings struct {
 	AHRS_Enabled   bool
 	DEBUG          bool
 	ReplayLog      bool // Startup only option. Cannot be changed during runtime.
+	ForeFlightOnly bool
 }
 
 type status struct {
@@ -529,6 +530,7 @@ func defaultSettings() {
 	globalSettings.AHRS_Enabled = false
 	globalSettings.DEBUG = false
 	globalSettings.ReplayLog = false //TODO: 'true' for debug builds.
+	globalSettings.ForeFlightOnly = false
 }
 
 func readSettings() {

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -59,6 +59,9 @@ func handleManagementConnection(conn *websocket.Conn) {
 			if msg.Setting == "DEBUG" {
 				globalSettings.DEBUG = msg.Value
 			}
+			if msg.Setting == "ForeFlightOnly" {
+				globalSettings.ForeFlightOnly = msg.Value
+			}
 
 			saveSettings()
 		}

--- a/main/network.go
+++ b/main/network.go
@@ -121,10 +121,10 @@ func refreshConnectedClients() {
 				}
 				newq := make([][]byte, 0)
 				sleepMode := false
-/*				if networkOutput.Port == 4000 { // Start off FF in sleep mode until something is received.
+				if globalSettings.ForeFlightOnly && networkOutput.Port == 4000 { // Start off FF in sleep mode until something is received.
 					sleepMode = true
 				}
-*/
+
 				outSockets[ipAndPort] = networkConnection{Conn: outConn, Ip: ip, Port: networkOutput.Port, Capability: networkOutput.Capability, sleepMode: sleepMode, sleepQueue: newq}
 			}
 			validConnections[ipAndPort] = true

--- a/web/index.html
+++ b/web/index.html
@@ -178,6 +178,18 @@
                             </div>
                         </div>
                     </div>
+		    <div class="form-group">
+			<label class="control-label col-xs-6">ForeFlight Traffic Mode</label>
+			<div class="col-xs-6">
+                            <div class="onoffswitch">
+                                <input type="checkbox" name="ForeFlightOnly" class="onoffswitch-checkbox" id="ff-onoffswitch" checked>
+                                <label class="onoffswitch-label" for="ff-onoffswitch">
+                                    <span class="onoffswitch-inner"></span>
+                                    <span class="onoffswitch-switch"></span>
+                                </label>
+                            </div>
+                        </div>
+		    </div>
                 </div>
             </div>
         </div>

--- a/web/js/stratux.js
+++ b/web/js/stratux.js
@@ -93,6 +93,7 @@ function connect() {
         $('input[name=GPS_Enabled]').prop('checked', status.GPS_Enabled);
         $('input[name=AHRS_Enabled]').prop('checked', status.AHRS_Enabled);
         $('input[name=DspTrafficSrc]').prop('checked', status.DEBUG);
+        $('input[name=ForeFlightOnly]').prop('checked', status.ForeFlightOnly);
     };
 }
 
@@ -148,5 +149,14 @@ $(document).ready(function () {
         };
         socket.send(JSON.stringify(msg));
     });
+    
+    $('input[name=ForeFlightOnly]').click(function () {
+        console.log('ForeFlightOnly clicked');
 
+        msg = {
+            setting: 'ForeFlightOnly',
+            state: $('input[name=ForeFlightOnly]').prop('checked')
+        };
+        socket.send(JSON.stringify(msg));
+    });
 });


### PR DESCRIPTION
How about something like this to handle #22.  It would allow users who are only using ForeFlight to turn on ForeFlight Traffic Mode.  Those using a different EFB or mixing and matching could leave this setting off.