### PR TITLE
New REST services with getter/setter for settings

### DIFF
--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -7,13 +7,15 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/http/httputil"    // used for debugging
+    "reflect"              // used for debugging
 	"strconv"
 	"time"
 )
 
 type SettingMessage struct {
-	Setting string `json:"setting"`
-	Value   bool   `json:"state"`
+	Setting  string `json:"setting"`
+	Value    bool   `json:"state"`
 }
 
 type InfoMessage struct {
@@ -26,7 +28,8 @@ func statusSender(conn *websocket.Conn) {
 	for {
 		<-timer.C
 
-		update, _ := json.Marshal(InfoMessage{status: &globalStatus, settings: &globalSettings})
+		// update, _ := json.Marshal(InfoMessage{status: &globalStatus, settings: &globalSettings})
+		update, _ := json.Marshal(&globalStatus)
 		_, err := conn.Write(update)
 
 		if err != nil {
@@ -40,6 +43,7 @@ func handleManagementConnection(conn *websocket.Conn) {
 	//	log.Printf("Web client connected.\n")
 	go statusSender(conn)
 
+    // TODO: once we have the new WebUI established, the websocket will nolonger receive settings changes
 	for {
 		var msg SettingMessage
 		err := websocket.JSON.Receive(conn, &msg)
@@ -70,9 +74,9 @@ func handleManagementConnection(conn *websocket.Conn) {
 }
 
 // AJAX call - /getTraffic. Responds with currently tracked traffic targets.
-
 func handleTrafficRequest(w http.ResponseWriter, r *http.Request) {
     w.Header().Set("Access-Control-Allow-Origin", "*")
+    w.Header().Set("Content-Type", "application/json")
 	/* From JSON package docs:
 	"JSON objects only support strings as keys; to encode a Go map type it must be of the form map[string]T (where T is any Go type supported by the json package)."
 	*/
@@ -90,6 +94,7 @@ func handleTrafficRequest(w http.ResponseWriter, r *http.Request) {
 // AJAX call - /getSituation. Responds with current situation (lat/lon/gdspeed/track/pitch/roll/heading/etc.)
 func handleSituationRequest(w http.ResponseWriter, r *http.Request) {
     w.Header().Set("Access-Control-Allow-Origin", "*")
+    w.Header().Set("Content-Type", "application/json")
 	situationJSON, _ := json.Marshal(&mySituation)
 	fmt.Fprintf(w, "%s\n", situationJSON)
 }
@@ -97,6 +102,7 @@ func handleSituationRequest(w http.ResponseWriter, r *http.Request) {
 // AJAX call - /getTowers. Responds with all ADS-B ground towers that have sent messages that we were able to parse, along with its stats.
 func handleTowersRequest(w http.ResponseWriter, r *http.Request) {
     w.Header().Set("Access-Control-Allow-Origin", "*")
+    w.Header().Set("Content-Type", "application/json")
 	towersJSON, _ := json.Marshal(&ADSBTowers)
 	fmt.Fprintf(w, "%s\n", towersJSON)
 }
@@ -104,13 +110,56 @@ func handleTowersRequest(w http.ResponseWriter, r *http.Request) {
 // AJAX call - /getSettings. Responds with all stratux.conf data.
 func handleSettingsGetRequest(w http.ResponseWriter, r *http.Request) {
     w.Header().Set("Access-Control-Allow-Origin", "*")
+    w.Header().Set("Content-Type", "application/json")
 	settingsJSON, _ := json.Marshal(&globalSettings)
 	fmt.Fprintf(w, "%s\n", settingsJSON)
 }
 
 // AJAX call - /setSettings. receives via POST command, any/all stratux.conf data.
 func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
-	//TODO need this setter function implemented
+    // define header in support of cross-domain AJAX
+    w.Header().Set("Access-Control-Allow-Origin", "*")
+    w.Header().Set("Access-Control-Allow-Method", "GET, POST, OPTIONS")
+    w.Header().Set("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
+    w.Header().Set("Content-Type", "application/json")
+    
+    // for an OPTION method request, we return header without processing.
+    // this insures we are recognized as supporting cross-domain AJAX REST calls
+    if (r.Method == "POST") {
+        raw, _ := httputil.DumpRequest(r, true)
+        log.Printf("handleSettingsSetRequest:raw: %s\n", raw)
+
+        decoder := json.NewDecoder(r.Body);
+        for {
+            var msg map[string]interface{} // support arbitrary JSON
+
+            err := decoder.Decode(&msg)
+            if err == io.EOF {
+                break
+            } else if err != nil {
+                log.Printf("handleSettingsSetRequest:error: %s\n", err.Error())
+            } else {
+                for key, val := range msg {
+                    log.Printf("handleSettingsSetRequest:json: testing for key:%s of type %s\n", key, reflect.TypeOf(val))
+                    switch key {
+                        case "UAT_Enabled":     globalSettings.UAT_Enabled = val.(bool)
+                        case "ES_Enabled":      globalSettings.ES_Enabled = val.(bool)
+                        case "GPS_Enabled":     globalSettings.GPS_Enabled = val.(bool)
+                        case "AHRS_Enabled":    globalSettings.AHRS_Enabled = val.(bool)
+                        case "DEBUG":           globalSettings.DEBUG = val.(bool)
+                        case "ReplayLog":       globalSettings.ReplayLog = val.(bool)
+                        case "PPM":             globalSettings.PPM = int(val.(float64))
+                        default:                log.Printf("handleSettingsSetRequest:json: unrecognized key:%s\n", key)
+                    }
+                }
+                saveSettings()
+            }
+        }
+        
+        // while it may be redundent, we return the latest settings
+        settingsJSON, _ := json.Marshal(&globalSettings)
+        fmt.Fprintf(w, "%s\n", settingsJSON)
+    }
 }
 
 func managementInterface() {

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -7,15 +7,13 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"net/http/httputil"    // used for debugging
-    "reflect"              // used for debugging
 	"strconv"
 	"time"
 )
 
 type SettingMessage struct {
-	Setting  string `json:"setting"`
-	Value    bool   `json:"state"`
+	Setting string `json:"setting"`
+	Value   bool   `json:"state"`
 }
 
 type InfoMessage struct {
@@ -28,8 +26,9 @@ func statusSender(conn *websocket.Conn) {
 	for {
 		<-timer.C
 
-		// update, _ := json.Marshal(InfoMessage{status: &globalStatus, settings: &globalSettings})
-		update, _ := json.Marshal(&globalStatus)
+		update, _ := json.Marshal(InfoMessage{status: &globalStatus, settings: &globalSettings})
+        // TODO: once we switch to hte new WebUI, we will not send settings via websocket
+		// update, _ := json.Marshal(&globalStatus)
 		_, err := conn.Write(update)
 
 		if err != nil {
@@ -140,7 +139,7 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
                 log.Printf("handleSettingsSetRequest:error: %s\n", err.Error())
             } else {
                 for key, val := range msg {
-                    log.Printf("handleSettingsSetRequest:json: testing for key:%s of type %s\n", key, reflect.TypeOf(val))
+                    // log.Printf("handleSettingsSetRequest:json: testing for key:%s of type %s\n", key, reflect.TypeOf(val))
                     switch key {
                         case "UAT_Enabled":     globalSettings.UAT_Enabled = val.(bool)
                         case "ES_Enabled":      globalSettings.ES_Enabled = val.(bool)

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -125,8 +125,8 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
     // for an OPTION method request, we return header without processing.
     // this insures we are recognized as supporting cross-domain AJAX REST calls
     if (r.Method == "POST") {
-        raw, _ := httputil.DumpRequest(r, true)
-        log.Printf("handleSettingsSetRequest:raw: %s\n", raw)
+        // raw, _ := httputil.DumpRequest(r, true)
+        // log.Printf("handleSettingsSetRequest:raw: %s\n", raw)
 
         decoder := json.NewDecoder(r.Body);
         for {


### PR DESCRIPTION
the new REST services for getting and setting the current set of user accessible settings include:

	UAT_Enabled    bool
	ES_Enabled     bool
	GPS_Enabled    bool
	AHRS_Enabled   bool
	DEBUG          bool
	ReplayLog      bool
	PPM            int

All of the existing REST services have been made to support cross-domain AJAx calling.

The above is in support of the new WebUI (to be submitted as follow-on branch). Once the new WebUI is committed, some of the existing data on the websocket should be deprecated.