### PR TITLE
add OwnshipModeS to UI; tweaked Settings field validation

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -177,9 +177,10 @@ func makeOwnshipReport() bool {
 
 	msg[1] = 0x01 // Alert status, address type.
 
-	msg[2] = byte((globalSettings.OwnshipModeS >> 16) & 0xFF) // Mode S address.
-	msg[3] = byte((globalSettings.OwnshipModeS >> 8) & 0xFF)  // Mode S address.
-	msg[4] = byte(globalSettings.OwnshipModeS & 0xFF)         // Mode S address.
+	code, _ := hex.DecodeString(globalSettings.OwnshipModeS)
+	msg[2] = code[0]	// Mode S address.
+	msg[3] = code[1]	// Mode S address.
+	msg[4] = code[2]	// Mode S address.
 
 	tmp := makeLatLng(mySituation.Lat)
 	msg[5] = tmp[0] // Latitude.
@@ -684,7 +685,7 @@ type settings struct {
 	DEBUG          bool
 	ReplayLog      bool // Startup only option. Cannot be changed during runtime.
 	PPM            int
-	OwnshipModeS   int32
+	OwnshipModeS   string
 	WatchList      string
 }
 

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"encoding/json"
+	"encoding/hex"
+	"strings"
 	"fmt"
 	"golang.org/x/net/websocket"
 	"io"
 	"log"
 	"net/http"
-	"strconv"
 	"time"
 )
 
@@ -159,15 +160,17 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 						globalSettings.WatchList = val.(string)
 					case "OwnshipModeS":
 						// Expecting a hex string less than 6 characters (24 bits) long.
-						hexc := val.(string)
-						if len(hexc) > 6 { // Too long.
+						if len(val.(string)) > 6 { // Too long.
 							continue
 						}
-						i, err := strconv.ParseInt(hexc, 16, 32)
-						if err != nil { // Number not valid.
+						vals := strings.ToUpper(val.(string))
+						hexn, _ := hex.DecodeString(vals)
+						hexs := strings.ToUpper(hex.EncodeToString(hexn))
+						if vals != hexs { // Number not valid.
+							log.Printf("handleSettingsSetRequest:OwnshipModeS: %s != %s\n", vals, hexs)
 							continue
 						}
-						globalSettings.OwnshipModeS = int32(i)
+						globalSettings.OwnshipModeS = vals
 					default:
 						log.Printf("handleSettingsSetRequest:json: unrecognized key:%s\n", key)
 					}

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -4,95 +4,108 @@ SettingsCtrl.$inject = ['$rootScope', '$scope', '$state', '$http']; // Inject my
 // create our controller function with all necessary logic
 function SettingsCtrl($rootScope, $scope, $state, $http) {
 
-    $scope.$parent.helppage = 'plates/settings-help.html';
-    
-    var toggles = ['UAT_Enabled', 'ES_Enabled', 'GPS_Enabled', 'AHRS_Enabled', 'DEBUG', 'ReplayLog']; // DEBUG is 'DspTrafficSrc'
-    var settings = {};
-    for (i = 0; i < toggles.length; i++) {
-        settings[toggles[i]] = undefined;
-    }
+	$scope.$parent.helppage = 'plates/settings-help.html';
+
+	var toggles = ['UAT_Enabled', 'ES_Enabled', 'GPS_Enabled', 'AHRS_Enabled', 'DEBUG', 'ReplayLog']; // DEBUG is 'DspTrafficSrc'
+	var settings = {};
+	for (i = 0; i < toggles.length; i++) {
+		settings[toggles[i]] = undefined;
+	}
 
 	function loadSettings(data) {
-            settings = angular.fromJson(data);
-            $scope.rawSettings = angular.toJson(data, true);
-			$scope.UAT_Enabled = settings.UAT_Enabled;
-            $scope.ES_Enabled = settings.ES_Enabled;
-            $scope.GPS_Enabled = settings.GPS_Enabled;
-            $scope.AHRS_Enabled = settings.AHRS_Enabled;
-            $scope.DEBUG = settings.DEBUG;
-            $scope.ReplayLog = settings.ReplayLog;
-            $scope.PPM = settings.PPM;
-			$scope.WatchList = settings.WatchList;
+		settings = angular.fromJson(data);
+		// consider using angular.extend()
+		$scope.rawSettings = angular.toJson(data, true);
+		$scope.UAT_Enabled = settings.UAT_Enabled;
+		$scope.ES_Enabled = settings.ES_Enabled;
+		$scope.GPS_Enabled = settings.GPS_Enabled;
+		$scope.AHRS_Enabled = settings.AHRS_Enabled;
+		$scope.DEBUG = settings.DEBUG;
+		$scope.ReplayLog = settings.ReplayLog;
+		$scope.PPM = settings.PPM;
+		$scope.WatchList = settings.WatchList;
+		$scope.OwnshipModeS = settings.OwnshipModeS;
 	}
+
+	function getSettings() {
+		// Simple GET request example (note: responce is asynchronous)
+		$http.get(URL_SETTINGS_GET).
+		then(function (response) {
+			loadSettings(response.data);
+			// $scope.$apply();
+		}, function (response) {
+			$scope.rawSettings = "error getting settings";
+			for (i = 0; i < toggles.length; i++) {
+				settings[toggles[i]] = false;
+			}
+
+		});
+	};
+
+	function setSettings(msg) {
+		// Simple POST request example (note: responce is asynchronous)
+		$http.post(URL_SETTINGS_SET, msg).
+		then(function (response) {
+			loadSettings(response.data);
+			// $scope.$apply();
+		}, function (response) {
+			$scope.rawSettings = "error setting settings";
+			for (i = 0; i < toggles.length; i++) {
+				settings[toggles[i]] = false;
+			}
+
+		});
+	}
+
+	getSettings();
+
+	$scope.$watchGroup(toggles, function (newValues, oldValues, scope) {
+		var newsettings = {}
+		var dirty = false;
+		for (i = 0; i < newValues.length; i++) {
+			if ((newValues[i] !== undefined) && (settings[toggles[i]] !== undefined)) {
+				if (newValues[i] !== settings[toggles[i]]) {
+					settings[toggles[i]] = newValues[i];
+					newsettings[toggles[i]] = newValues[i];
+					dirty = true;
+				};
+			}
+		}
+		if (dirty) {
+			// console.log(angular.toJson(newsettings));
+			setSettings(angular.toJson(newsettings));
+		}
+	});
+
+	$scope.updateppm = function () {
+		if (($scope.PPM !== undefined) && ($scope.PPM !== null) && ($scope.PPM !== settings["PPM"])) {
+			settings["PPM"] = parseInt($scope.PPM);
+			newsettings = {
+				"PPM": parseInt($scope.PPM)
+			};
+			// console.log(angular.toJson(newsettings));
+			setSettings(angular.toJson(newsettings));
+		}
+	};
 	
-    function getSettings() {
-        // Simple GET request example (note: responce is asynchronous)
-        $http.get(URL_SETTINGS_GET).
-        then(function (response) {
-			loadSettings (response.data);
-            // $scope.$apply();
-        }, function (response) {
-            $scope.rawSettings = "error getting settings";
-            for (i = 0; i < toggles.length; i++) {
-                settings[toggles[i]] = false;
-            }
-
-        });
-    };
-
-    function setSettings(msg) {
-        // Simple POST request example (note: responce is asynchronous)
-        $http.post(URL_SETTINGS_SET, msg).
-        then(function (response) {
-			loadSettings (response.data);
-            // $scope.$apply();
-        }, function (response) {
-            $scope.rawSettings = "error setting settings";
-            for (i = 0; i < toggles.length; i++) {
-                settings[toggles[i]] = false;
-            }
-
-        });
-    }
-
-    getSettings();
-
-    $scope.$watchGroup(toggles, function (newValues, oldValues, scope) {
-        var newsettings = {}
-        var dirty = false;
-        for (i = 0; i < newValues.length; i++) {
-            if ((newValues[i] !== undefined) && (settings[toggles[i]] !== undefined)) {
-                if (newValues[i] !== settings[toggles[i]]) {
-                    settings[toggles[i]] = newValues[i];
-                    newsettings[toggles[i]] = newValues[i];
-                    dirty = true;
-                };
-            }
-        }
-        if (dirty) {
-            console.log(angular.toJson(newsettings));
-            setSettings(angular.toJson(newsettings));
-        }
-    });
-
-    $scope.updatewatchlist = function() {
-        if (($scope.WatchList !== undefined) && ($scope.WatchList !== null) && $scope.WatchList !== settings["WatchList"]) {
-            settings["WatchList"] = $scope.WatchList.toUpperCase();
-            newsettings = {
-                "WatchList": $scope.WatchList.toUpperCase()
-            };
-            console.log(angular.toJson(newsettings));
-            setSettings(angular.toJson(newsettings));
-        }
-    };
-	    $scope.updateppm = function() {
-        if (($scope.PPM !== undefined) && ($scope.PPM !== null) && $scope.PPM !== settings["PPM"]) {
-            settings["PPM"] = parseInt($scope.PPM);
-            newsettings = {
-                "PPM": parseInt($scope.PPM)
-            };
-            console.log(angular.toJson(newsettings));
-            setSettings(angular.toJson(newsettings));
-        }
-    };
+	$scope.updatewatchlist = function () {
+		if ($scope.WatchList !== settings["WatchList"]) {
+			settings["WatchList"] = $scope.WatchList.toUpperCase();
+			newsettings = {
+				"WatchList": $scope.WatchList.toUpperCase()
+			};
+			// console.log(angular.toJson(newsettings));
+			setSettings(angular.toJson(newsettings));
+		}
+	};
+	$scope.updatemodes = function () {
+		if ($scope.OwnshipModeS !== settings["OwnshipModeS"]) {
+			settings["OwnshipModeS"] = $scope.OwnshipModeS.toUpperCase();
+			newsettings = {
+				"OwnshipModeS": $scope.OwnshipModeS.toUpperCase()
+			};
+			// console.log(angular.toJson(newsettings));
+			setSettings(angular.toJson(newsettings));
+		}
+	};
 };

--- a/web/plates/js/status.js
+++ b/web/plates/js/status.js
@@ -24,7 +24,7 @@ function StatusCtrl($rootScope, $scope, $state, $http) {
 
 		socket.onclose = function (msg) {
 			// $scope.ConnectStyle = "label-danger";
-			$scope.ConnectState = "Closed";
+			$scope.ConnectState = "Disconnected";
 			$scope.$apply();
 			setTimeout(connect, 1000);
 		};

--- a/web/plates/js/weather.js
+++ b/web/plates/js/weather.js
@@ -10,6 +10,8 @@ function WeatherCtrl($rootScope, $scope, $state, $http, $interval) {
 	$scope.$parent.helppage = 'plates/weather-help.html';
 	$scope.data_list = [];
 	$scope.watch_list = [];
+	$scope.data_count = 0;
+	$scope.watch_count = 0;
 
 	function updateWatchList() {
 		$scope.watching = CONF_WATCHLIST;

--- a/web/plates/settings-help.html
+++ b/web/plates/settings-help.html
@@ -1,20 +1,28 @@
 <div class="section text-left help-page">
-    <p>The <strong>Settings</strong> page provides both control and configuration of your Stratux device.</p>
+	<p>The <strong>Settings</strong> page provides both control and configuration of your Stratux device.</p>
 
-    <p>Use the toggles in the <strong>Hardware</strong> section to control which devices are active.</p>
-    <p class="text-warning">NOTE: Only hardware toggled on here, will appear on the
-        <stron>Status</stron> page.</p>
+	<p>Use the toggles in the <strong>Hardware</strong> section to control which devices are active.</p>
+	<p class="text-warning">NOTE: Only hardware toggled on here, will appear on the
+		<stron>Status</stron> page.</p>
 
-    <p>The <strong>Diagnostics</strong> section helps with debugging and communicating with the Stratux project contributors via GitHub and the reddit subgroup.
-        <ul class="list-simple">
-            <li>Toggling <strong>Traffic Source</strong> adds text for traffic targets within your navigation application. Traffic received via UAT will display <code>u</code> while traffic received via 1090 will display <code>e</code>.</li>
-            <li>Toggling <strong>Record Logs</strong> enables logging to a series of files for your Stratux device including data recorded for UAT traffic and weather, 1090 traffic, GPS messages, and AHRS messages. The log files are accessible from the <strong>Logs</strong> menu available on the left.</li>
-        </ul>
+	<p>The <strong>Diagnostics</strong> section helps with debugging and communicating with the Stratux project contributors via GitHub and the reddit subgroup.
+		<ul class="list-simple">
+			<li>Toggling <strong>Traffic Source</strong> adds text for traffic targets within your navigation application. Traffic received via UAT will display <code>u</code> while traffic received via 1090 will display <code>e</code>.</li>
+			<li>Toggling <strong>Record Logs</strong> enables logging to a series of files for your Stratux device including data recorded for UAT traffic and weather, 1090 traffic, GPS messages, and AHRS messages. The log files are accessible from the <strong>Logs</strong> menu available on the left.</li>
+		</ul>
 
-    <p>The <strong>Configuration</strong> section lets you adjust the default operation of your Stratux device.</p>
-    <ul>
-        <li>The SDR (software defined radio) receiver support error correction. From the Raspberry Pi, you may use the command <code>kal -g 48 -s GSM850</code> to scan for available channels in your area. Then use the command <code>kal -g 48 -c <em>channel#</em></code> to calculate the PPM.  <div class="text-warning">NOTE: You will need to perform all commands as <code>root</code> by issuing the command: <code>sudo su -</code>. You will need to stop the Stratux software before running the calibration process. You can stop all of the Stratux processes with the command: <code>pkill screen</code>.</div></li>
-        <li>The <strong>Weather</strong> page uses a user-defined <em>watch list</em> to filter the large volume of ADS-B weather messages for display. Define a list of identifiers (airport, VOR, etc) separated by a spaces. For example <code>KBOS EEN LAH LKP</code>. You may change this list at any time and the <strong>Weather</strong> page will start watching for the updated list immediately.</li>
-        <li>Addiitonal settings will be added in future releases.</li>
-    </ul>
+		<p>The <strong>Configuration</strong> section lets you adjust the default operation of your Stratux device.</p>
+		<ul class="list-simple">
+			<li>To avoid having your own aircraft appear as traffic, and scare the bejeezus our of you, you may provide your <strong>Mode S code</strong>. You can find this value in the FAA N-Number Registry for your aircraft. You should use the hexadecimal value (not the octal value) for this setting. No validation is done so please ensure you enter your valide Mode S value.
+			</li>
+			<li>The <strong>Weather</strong> page uses a user-defined <strong>Watch List</strong> to filter the large volume of ADS-B weather messages for display. Define a list of identifiers (airport, VOR, etc) separated by a spaces. For example <code>KBOS EEN LAH LKP</code>. You may change this list at any time and the <strong>Weather</strong> page will start watching for the updated list immediately.
+				<br/>
+				<span class="text-warning">NOTE: To save your changes, you must either tap somehwere else on the page or hit <code>ENTER</code> or <code>RETURN</code> or <code>GO</code> (or whatever your keyboard indicates).</span>
+			</li>
+			<li>The SDR (software defined radio) receiver support an adjustment in the form of a <strong>PPM Correction</strong>. From the Raspberry Pi, you may use the command <code>kal -g 48 -s GSM850</code> to scan for available channels in your area. Then use the command <code>kal -g 48 -c <em>channel#</em></code> to calculate the PPM.
+				<br/>
+				<span class="text-warning">NOTE: You will need to perform all commands as <code>root</code> by issuing the command: <code>sudo su -</code>. You will need to stop the Stratux software before running the calibration process. You can stop all of the Stratux processes with the command: <code>pkill screen</code>.</span>
+			</li>
+			<li>Addiitonal settings will be added in future releases.</li>
+		</ul>
 </div>

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -56,17 +56,24 @@
 			<div class="panel-heading">Configuration</div>
 			<div class="panel-body">
 				<div class="form-group reset-flow">
-					<label class="control-label col-xs-5">PPM Correction</label>
-					<form name="ppmForm" ng-submit="updateppm()" novalidate>
+					<label class="control-label col-xs-5">Mode S Code (Hex)</label>
+					<form name="modeForm" ng-submit="updatemodes()" novalidate>
 						<!-- type="number" not supported except on mobile -->
-						<input class="col-xs-7" type="number_format" required ng-model="PPM" placeholder="integer" />
+						<input class="col-xs-7" type="string" required ng-model="OwnshipModeS" placeholder="FAA HEX code" ng-blur="updatemodes()" />
 					</form>
 				</div>
 				<div class="form-group reset-flow">
 					<label class="control-label col-xs-5">Watch List</label>
-					<form name="ppmForm" ng-submit="updatewatchlist()" novalidate>
+					<form name="watchForm" ng-submit="updatewatchlist()" novalidate>
 						<!-- type="number" not supported except on mobile -->
-						<input class="col-xs-7" type="string" required ng-model="WatchList" placeholder="space delimeted identifiers" />
+						<input class="col-xs-7" type="string" required ng-model="WatchList" placeholder="space delimeted identifiers" ng-blur="updatewatchlist()" />
+					</form>
+				</div>
+				<div class="form-group reset-flow">
+					<label class="control-label col-xs-5">PPM Correction</label>
+					<form name="ppmForm" ng-submit="updateppm()" novalidate>
+						<!-- type="number" not supported except on mobile -->
+						<input class="col-xs-7" type="number_format" required ng-model="PPM" placeholder="integer" ng-blur="updateppm()" />
 					</form>
 				</div>
 			</div>
@@ -75,7 +82,7 @@
 </div>
 
 <!--
-<div class="col-sm-12">
+ssh<div class="col-sm-12">
 	<div class="panel panel-default">
 		<div class="panel-heading">Raw Configuration</div>
 		<div class="panel-body">


### PR DESCRIPTION
The OwnShipModeS value is assumed to come in as string (HEX) but goes back out as an integer, this really messes with the normal processing of configuration settings. Since teh HEX string is eas yfor users to enter in the UI, it made sense to preserve that in the UI and in the stratux.conf file. Therefore, it becomes necessary to work wit hthe HEX string in the Go code.

I was able to test all of the GO code with the exception of the makeOwnshipReport();

There was an issue when attempting to clear the WeatherList. It would not allow the list to be reset back to 'blank'. I updated the validation code to handle this. I also now detect field focus changes to trigger validation and storage rather than just triggering from the 'form submit' event.