### PR TITLE
Updated GPS initialization and parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Apps with stratux recognition/support:
 * Seattle Avionics FlyQ EFB 2.1.1+.
 * AvNav EFB 2.0.0+.
 * Naviator.
+* WingX Pro7 8.6.2+
 
 Tested weather/traffic displays:
 * ForeFlight 7+ - weather, traffic, AHRS.
-* WingX - weather & traffic.
 * Avare
 * iFly 740 - weather & traffic.
 

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -363,9 +363,9 @@ func makeSXHeartbeat() []byte {
 
 	// Version code. Messy parsing to fit into four bytes.
 	//FIXME: This is why we can't have nice things.
-	v := stratuxVersion[1:]                // Skip first character, should be 'v'.
-	m_str := v[0:strings.Index(v, ".")]    // Major version.
-	mib_str := v[strings.Index(v, ".")+1:] // Minor and build version.
+	thisVers := stratuxVersion[1:]                // Skip first character, should be 'v'.
+	m_str := v[0:strings.Index(thisVers, ".")]    // Major version.
+	mib_str := v[strings.Index(thisVers, ".")+1:] // Minor and build version.
 
 	tp := 0 // Build "type".
 	mi_str := ""

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -363,9 +363,9 @@ func makeSXHeartbeat() []byte {
 
 	// Version code. Messy parsing to fit into four bytes.
 	//FIXME: This is why we can't have nice things.
-	thisVers := stratuxVersion[1:]                // Skip first character, should be 'v'.
-	m_str := v[0:strings.Index(thisVers, ".")]    // Major version.
-	mib_str := v[strings.Index(thisVers, ".")+1:] // Minor and build version.
+	thisVers := stratuxVersion[1:]                       // Skip first character, should be 'v'.
+	m_str := thisVers[0:strings.Index(thisVers, ".")]    // Major version.
+	mib_str := thisVers[strings.Index(thisVers, ".")+1:] // Minor and build version.
 
 	tp := 0 // Build "type".
 	mi_str := ""

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -413,6 +413,16 @@ func makeSXHeartbeat() []byte {
 		msg[13] = msg[13] | (1 << 6)
 	}
 
+	// Valid/Enabled: GPS Enabled portion.
+	if globalSettings.GPS_Enabled {
+		msg[13] = msg[13] | (1 << 7)
+	}
+
+	// Valid/Enabled: AHRS Enabled portion.
+	if globalSettings.AHRS_Enabled {
+		msg[12] = 1 << 0
+	}
+
 	// Valid/Enabled: last bit unused.
 
 	// Connected hardware: number of radios.

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -703,6 +703,7 @@ func cpuTempMonitor() {
 func updateStatus() {
 	if isGPSValid() {
 		globalStatus.GPS_satellites_locked = mySituation.Satellites
+                globalStatus.GPS_satellites_seen = mySituation.SatellitesSeen
 		globalStatus.GPS_satellites_tracked = mySituation.SatellitesTracked
 		if mySituation.quality == 2 {
 			globalStatus.GPS_solution = "DGPS (SBAS / WAAS)"
@@ -711,7 +712,7 @@ func updateStatus() {
 		} else if mySituation.quality == 6 {
 			globalStatus.GPS_solution = "Dead Reckoning"
 		} else {
-			globalStatus.GPS_solution = "N/A"
+			globalStatus.GPS_solution = "No Fix"
 		}
 	}
 
@@ -988,6 +989,7 @@ type status struct {
 	ES_messages_last_minute  uint
 	ES_messages_max          uint
 	GPS_satellites_locked    uint16
+	GPS_satellites_seen	 uint16
 	GPS_satellites_tracked	 uint16
 	GPS_connected            bool
 	GPS_solution             string

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -459,8 +459,8 @@ func makeSXHeartbeat() []byte {
 	// Number of GPS satellites locked.
 	msg[16] = byte(globalStatus.GPS_satellites_locked)
 
-	//FIXME: Number of satellites connected. ??
-	msg[17] = 0xFF
+	// Number of satellites tracked
+	msg[17] = byte(globalStatus.GPS_satellites_tracked)
 
 	// Summarize number of UAT and 1090ES traffic targets for reports that follow.
 	var uat_traffic_targets uint16
@@ -703,10 +703,13 @@ func cpuTempMonitor() {
 func updateStatus() {
 	if isGPSValid() {
 		globalStatus.GPS_satellites_locked = mySituation.Satellites
+		globalStatus.GPS_satellites_tracked = mySituation.SatellitesTracked
 		if mySituation.quality == 2 {
-			globalStatus.GPS_solution = "DGPS (WAAS)"
+			globalStatus.GPS_solution = "DGPS (SBAS / WAAS)"
 		} else if mySituation.quality == 1 {
 			globalStatus.GPS_solution = "3D GPS"
+		} else if mySituation.quality == 6 {
+			globalStatus.GPS_solution = "Dead Reckoning"
 		} else {
 			globalStatus.GPS_solution = "N/A"
 		}
@@ -985,6 +988,7 @@ type status struct {
 	ES_messages_last_minute  uint
 	ES_messages_max          uint
 	GPS_satellites_locked    uint16
+	GPS_satellites_tracked	 uint16
 	GPS_connected            bool
 	GPS_solution             string
 	RY835AI_connected        bool
@@ -1107,7 +1111,8 @@ func printStats() {
 		log.Printf(" - CPUTemp=%.02f deg C, MemStats.Alloc=%s, MemStats.Sys=%s, totalNetworkMessagesSent=%s\n", globalStatus.CPUTemp, humanize.Bytes(uint64(memstats.Alloc)), humanize.Bytes(uint64(memstats.Sys)), humanize.Comma(int64(totalNetworkMessagesSent)))
 		log.Printf(" - UAT/min %s/%s [maxSS=%.02f%%], ES/min %s/%s\n, Total traffic targets tracked=%s", humanize.Comma(int64(globalStatus.UAT_messages_last_minute)), humanize.Comma(int64(globalStatus.UAT_messages_max)), float64(maxSignalStrength)/10.0, humanize.Comma(int64(globalStatus.ES_messages_last_minute)), humanize.Comma(int64(globalStatus.ES_messages_max)), humanize.Comma(int64(len(seenTraffic))))
 		if globalSettings.GPS_Enabled {
-			log.Printf(" - Last GPS fix: %s, GPS solution type: %d, NACp: %d, est accuracy %.02f m\n", humanize.Time(mySituation.LastFixLocalTime), mySituation.quality, mySituation.NACp, mySituation.Accuracy)
+			log.Printf(" - Last GPS fix: %s, GPS solution type: %d using %v satellites (%v tracked), NACp: %d, est accuracy %.02f m\n", humanize.Time(mySituation.LastFixLocalTime), mySituation.quality, mySituation.Satellites, mySituation.SatellitesTracked, mySituation.NACp, mySituation.Accuracy)
+			log.Printf(" - GPS vertical velocity: %.02f ft/sec; GPS vertical accuracy: %v m\n", mySituation.GPSVertVel, mySituation.AccuracyVert)
 		}
 	}
 }

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -362,10 +362,13 @@ func makeSXHeartbeat() []byte {
 	msg[3] = 1 // "message version".
 
 	// Firmware version. First 4 bytes of build.
-	msg[4] = byte(stratuxBuild[0])
-	msg[5] = byte(stratuxBuild[1])
-	msg[6] = byte(stratuxBuild[2])
-	msg[7] = byte(stratuxBuild[3])
+	build_byte := make([]byte, hex.DecodedLen(len(stratuxBuild)))
+	hex.Decode(build_byte, []byte(stratuxBuild))
+
+	msg[4] = build_byte[0]
+	msg[5] = build_byte[1]
+	msg[6] = build_byte[2]
+	msg[7] = build_byte[3]
 
 	//TODO: Hardware revision.
 	msg[8] = 0xFF

--- a/web/plates/gps.html
+++ b/web/plates/gps.html
@@ -18,10 +18,10 @@
 				<div class="row">
 					<strong class="col-xs-6 text-center">Location:</strong>
 					<strong class="col-xs-6 text-center">Track:</strong>
-				</div>
+                       		</div>
 				<div class="row">
-					<span class="col-xs-6 text-center">{{gps_lat}}, {{gps_lon}} &plusmn; {{gps_accuracy}} m</span>
-					<span class="col-xs-6 text-center">{{gps_track}}&deg; @ {{gps_speed}}KTS @ {{gps_alt}} ft</span>
+					<span class="col-xs-6 text-center">{{gps_lat}}, {{gps_lon}} &plusmn; {{gps_accuracy}} m <br> {{gps_alt}} &plusmn; {{gps_vert_accuracy}} ft  @ {{gps_vert_speed}} ft/min</span>
+					<span class="col-xs-6 text-center">{{gps_track}}&deg; @ {{gps_speed}} KTS</span>
 				</div>
 			</div>
 		</div>

--- a/web/plates/js/gps.js
+++ b/web/plates/js/gps.js
@@ -60,18 +60,22 @@ function GPSCtrl($rootScope, $scope, $state, $http, $interval) {
 		/*	not currently used
 		$scope.gps_satellites = status.Satellites;
 		*/
-		$scope.gps_accuracy = Math.round(status.Accuracy);
+		$scope.gps_accuracy = status.Accuracy.toFixed(1);
+                $scope.gps_vert_accuracy = (status.AccuracyVert*3.2808).toFixed(1); // accuracy is in meters, need to display in ft
+
 
 		// NACp should be an integer value in the range of 0 .. 11
 		// var accuracies = ["≥ 10 NM", "< 10 NM", "< 4 NM", "< 2 NM", "< 1 NM", "< 0.5 NM", "< 0.3 NM", "< 0.1 NM", "< 100 m", "< 30 m", "< 10 m", "< 3 m"];
 		// $scope.gps_accuracy = accuracies[status.NACp];
 		// "LastFixLocalTime":"2015-10-11T16:47:03.523085162Z"
 
-		$scope.gps_lat = status.Lat.toPrecision(6); // result is string
-		$scope.gps_lon = status.Lng.toPrecision(6); // result is string
+		$scope.gps_lat = status.Lat.toFixed(5); // result is string
+		$scope.gps_lon = status.Lng.toFixed(5); // result is string
 		$scope.gps_alt = Math.round(status.Alt);
 		$scope.gps_track = status.TrueCourse;
 		$scope.gps_speed = status.GroundSpeed;
+                $scope.gps_vert_speed = status.GPSVertVel.toFixed(1);
+
 		// "LastGroundTrackTime":"0001-01-01T00:00:00Z"
 
 		/* not currently used 
@@ -103,9 +107,9 @@ function GPSCtrl($rootScope, $scope, $state, $http, $interval) {
 	};
 
 	var updateStatus = $interval(function () {
-		// refresh GPS/AHRS status once each second (aka polling)
+		// refresh GPS/AHRS status once each half second (aka polling)
 		getStatus();
-	}, (1 * 1000), 0, false);
+	}, (1 * 500), 0, false);
 
 	$state.get('gps').onEnter = function () {
 		// everything gets handled correctly by the controller

--- a/web/plates/js/status.js
+++ b/web/plates/js/status.js
@@ -50,6 +50,7 @@ function StatusCtrl($rootScope, $scope, $state, $http, $interval) {
 			$scope.ES_messages_max = status.ES_messages_max;
 			$scope.GPS_satellites_locked = status.GPS_satellites_locked;
 			$scope.GPS_satellites_tracked = status.GPS_satellites_tracked;
+			$scope.GPS_satellites_seen = status.GPS_satellites_seen;
 			$scope.GPS_solution = status.GPS_solution;
 			$scope.RY835AI_connected = status.RY835AI_connected;
 

--- a/web/plates/js/status.js
+++ b/web/plates/js/status.js
@@ -49,6 +49,7 @@ function StatusCtrl($rootScope, $scope, $state, $http, $interval) {
 			$scope.ES_messages_last_minute = status.ES_messages_last_minute;
 			$scope.ES_messages_max = status.ES_messages_max;
 			$scope.GPS_satellites_locked = status.GPS_satellites_locked;
+			$scope.GPS_satellites_tracked = status.GPS_satellites_tracked;
 			$scope.GPS_solution = status.GPS_solution;
 			$scope.RY835AI_connected = status.RY835AI_connected;
 

--- a/web/plates/status.html
+++ b/web/plates/status.html
@@ -62,7 +62,7 @@
 				</div>
 				<div class="row" ng-class="{'section_invisible': !visible_gps}">
 					<label class="col-xs-6">GPS satellites:</label>
-					<span class="col-xs-6">{{GPS_satellites_locked}} used; {{GPS_satellites_tracked}} tracked</span>
+					<span class="col-xs-6">{{GPS_satellites_locked}} in solution; {{GPS_satellites_seen}} seen; {{GPS_satellites_tracked}} tracked</span>
 				</div>
 				<div class="row" ng-class="{'section_invisible': !visible_ahrs}">
 					<label class="col-xs-6">AHRS:</label>

--- a/web/plates/status.html
+++ b/web/plates/status.html
@@ -62,7 +62,7 @@
 				</div>
 				<div class="row" ng-class="{'section_invisible': !visible_gps}">
 					<label class="col-xs-6">GPS satellites:</label>
-					<span class="col-xs-6">{{GPS_satellites_locked}}</span>
+					<span class="col-xs-6">{{GPS_satellites_locked}} used; {{GPS_satellites_tracked}} tracked</span>
 				</div>
 				<div class="row" ng-class="{'section_invisible': !visible_ahrs}">
 					<label class="col-xs-6">AHRS:</label>


### PR DESCRIPTION
Multiple changes to GPS handling. 
- Configure GNSS and NMEA messages at cold startup
- Fixed byte-order bug on UART configuration
- Set UART bit rate to 38400 bps. (Prevents message drops at 9600 bps / 10Hz; more reliable than higher rates)
- Add validation of NMEA message checksums
- Add support for u-blox 'PUBX' NMEA messages to reduce bandwidth requirement and simplify future satellite constellation parsing
- Improved horizontal accuracy calculation
- Add vertical velocity and vertical accuracy; update UI 'GPS/AHRS' page
- Add satellites tracked and satellites seen; update UI 'Status' page

Changes tested on u-blox M8 (RY835AI UART) and u-blox 7 (VK-172 USB). Should be compatible with all u-blox 6, 7, and 8 series GPS.