### PR TITLE
Delay start of UART reads. Link dev logs to web UI.

### DIFF
--- a/main/ry835ai.go
+++ b/main/ry835ai.go
@@ -232,7 +232,7 @@ func initGPSSerial() bool {
 	cfg[3] = 0x00 // res1.
         
         //      [   7   ] [   6   ] [   5   ] [   4   ]
-	//	0000 0000 0000 0000 1000 0000 1100 0000
+	//	0000 0000 0000 0000 0000 10x0 1100 0000
 	// UART mode. 0 stop bits, no parity, 8 data bits. Little endian order.
 	cfg[4] = 0xC0
 	cfg[5] = 0x08
@@ -261,8 +261,11 @@ func initGPSSerial() bool {
 	cfg[19] = 0x00 //pad.
 
 	p.Write(makeUBXCFG(0x06, 0x00, 20, cfg))
+//	time.Sleep(100* time.Millisecond) // pause and wait for the GPS to finish configuring itself before closing / reopening the port
 	p.Close()
 
+
+	time.Sleep(250*time.Millisecond)
 	// Re-open port at 38400 baud so we can read messages
 	serialConfig = &serial.Config{Name: device, Baud: 38400}
 	p, err = serial.OpenPort(serialConfig)

--- a/web/plates/logs.html
+++ b/web/plates/logs.html
@@ -7,8 +7,14 @@
             <i class="fa fa-cloud feature-icon text-primary"></i>
         </div>
         <div>
-            this space reserved to display the various logs
+            <a href="../logs/stratux.log">stratux.log</a>
         </div>
+	<div>
+            <a href="../logs/stratux/">SDR, AHRS, and GPS logs</a>	  
+	</div>
+	<div>
+            (Enable device logging on "Settings" page)
+	</dib>
     </div>
 </div>
 <div class="col-sm-6">


### PR DESCRIPTION
1. Added 250 ms delay after GPS initialization / setup. This will let it "settle" at 38.4 kbps before opening the port to read NMEA messages. This seems to solve the "extended ASCII" errors we were seeing.

2. Add links to /logs/stratux.log and /logs/stratux/ to "Logs" page of web UI.