### PR TITLE
Fix webUI zero GS bug

### DIFF
--- a/web/plates/js/traffic.js
+++ b/web/plates/js/traffic.js
@@ -36,10 +36,15 @@ function TrafficCtrl($rootScope, $scope, $state, $http, $interval) {
 		new_traffic.tail = obj.Tail;
 		new_traffic.lat = dmsString(obj.Lat);
 		new_traffic.lon = dmsString(obj.Lng);
-		var n = Math.round(obj.Alt / 100) * 100;
+		var n = Math.round(obj.Alt / 25) * 25;
 		new_traffic.alt = n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-		new_traffic.heading = Math.round(obj.Track / 10) * 10;
-		new_traffic.speed = Math.round(obj.Speed / 10) * 10;
+		new_traffic.heading = Math.round(obj.Track / 5) * 5;
+		var s = Math.round(obj.Speed / 5) * 5;
+		if (obj.Speed_valid) {
+			new_traffic.speed = s.toString();
+		} else {
+			new_traffic.speed = "---";
+		}
 		new_traffic.vspeed = Math.round(obj.Vvel / 100) * 100
 		new_traffic.age = Date.parse(obj.Last_seen);
 		new_traffic.time = utcTimeString(new_traffic.age);

--- a/web/plates/traffic.html
+++ b/web/plates/traffic.html
@@ -28,7 +28,7 @@
 						<span ng-hide="aircraft.tail" ng-class="'label traffic-style'+aircraft.src"><strong class="text-muted">{{aircraft.icao}}</strong></span>
 					</span>
 
-					<span class="col-xs-3 text-right">{{aircraft.speed}}KTS</span>
+					<span class="col-xs-3 text-right">{{aircraft.speed}} KTS</span>
 					<span class="col-xs-3 text-right">{{aircraft.alt}}</span>
 					<span class="col-xs-1 small col-padding-shift-right text-muted">
 						<span ng-show="aircraft.vspeed > 0"><span class="fa fa-ascent"></span>{{aircraft.vspeed}}</span>


### PR DESCRIPTION
Update traffic.js to parse "Speed_valid" before writing ground speed. If speed is invalid, display "---" instead of "0".

Update rounding to show alt in 25' incremenents, and GS/heading in increments of 5 units.