### PR TITLE
Fix transposed S/T in base40 decoding

### DIFF
--- a/dump978/uat_decode.c
+++ b/dump978/uat_decode.c
@@ -267,7 +267,8 @@ static void uat_display_sv(const struct uat_adsb_mdb *mdb, FILE *to)
             mdb->tisb_site_id);
 }
 
-static char base40_alphabet[40] = "0123456789ABCDEFGHIJKLMNOPQRTSUVWXYZ  ..";
+static char base40_alphabet[40] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ  ..";
+
 static void uat_decode_ms(uint8_t *frame, struct uat_adsb_mdb *mdb)
 {
     uint16_t v;


### PR DESCRIPTION
the code at mutability/dump978 posted a fix for a typo in the base 40 decode. the 'S' and 'T' letters were transposed in the reference string.

reference: https://github.com/mutability/dump978/commit/564902f53b0da7b095ccc5bf2ff28dda433372dd