### PR TITLE
Detect disconnected GPS. Update web UI and attempt reconnect.

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -713,20 +713,27 @@ func cpuTempMonitor() {
 }
 
 func updateStatus() {
+	if mySituation.quality == 2 {
+		globalStatus.GPS_solution = "DGPS (SBAS / WAAS)"
+	} else if mySituation.quality == 1 {
+		globalStatus.GPS_solution = "3D GPS"
+	} else if mySituation.quality == 6 {
+		globalStatus.GPS_solution = "Dead Reckoning"
+	} else {
+		globalStatus.GPS_solution = "No Fix"
+	}
+	if !isGPSConnected() {
+		mySituation.Satellites = 0
+		mySituation.SatellitesSeen = 0
+		mySituation.SatellitesTracked = 0
+		mySituation.quality = 0
+		globalStatus.GPS_solution = "Disconnected"
+		globalStatus.GPS_connected = false
+	}
+
 	globalStatus.GPS_satellites_locked = mySituation.Satellites
 	globalStatus.GPS_satellites_seen = mySituation.SatellitesSeen
 	globalStatus.GPS_satellites_tracked = mySituation.SatellitesTracked
-	if isGPSValid() {
-		if mySituation.quality == 2 {
-			globalStatus.GPS_solution = "DGPS (SBAS / WAAS)"
-		} else if mySituation.quality == 1 {
-			globalStatus.GPS_solution = "3D GPS"
-		} else if mySituation.quality == 6 {
-			globalStatus.GPS_solution = "Dead Reckoning"
-		} else {
-			globalStatus.GPS_solution = "No Fix"
-		}
-	}
 
 	// Update Uptime value
 	globalStatus.Uptime = int64(stratuxClock.Milliseconds)


### PR DESCRIPTION
Fixes #235.

This change detects if it's been more than five seconds since a valid NMEA message has been received.

If so, solution status is changed to "Disconnected", mySituation.quality and satellite counts are zeroed, and we break out of the gpsSerialReader() routine. This allows the GPS to reinitialize without spawning multiple instances of this goroutine.