### PR TITLE
GPS improvements: Support velocity / heading on older receivers; resolve stability issue related to disconnects

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -722,7 +722,8 @@ func updateStatus() {
 	} else {
 		globalStatus.GPS_solution = "No Fix"
 	}
-	if !isGPSConnected() {
+
+	if !(globalStatus.GPS_connected) || !(isGPSConnected()) { // isGPSConnected looks for valid NMEA messages. GPS_connected is set by gpsSerialReader and will immediately fail on disconnected USB devices, or in a few seconds after "blocked" comms on ttyAMA0.
 		mySituation.Satellites = 0
 		mySituation.SatellitesSeen = 0
 		mySituation.SatellitesTracked = 0

--- a/main/ry835ai.go
+++ b/main/ry835ai.go
@@ -642,7 +642,7 @@ func processNMEALine(l string) bool {
 	} else if (x[0] == "GNVTG") || (x[0] == "GPVTG") { // Ground track information.
 		mySituation.mu_GPS.Lock()
 		defer mySituation.mu_GPS.Unlock()
-		if len(x) < 10 {
+		if len(x) < 9 { // Reduce from 10 to 9 to allow parsing by devices pre-NMEA v2.3
 			return false
 		}
 		trueCourse := uint16(0)


### PR DESCRIPTION
**Add support for velocity and heading on pre-NMEA v2.3 receivers.** 
- NMEA v2.3 added 10th field ("posMode") to the VTG track / speed message; it's not used by Stratux, but the NMEA parser would not accept VGT messages with fewer than 10 fields.
- This change adds support for pre-2.3 receivers (e.g.  Delorme Earthmate LT-40).

**Resolve a stability issue related to disconnecting and reconnecting GPS hardware.** 
- The GPS tty port reader is initialized without a no-read timeout, so gpsSerialReader() gets blocked when a GPS is disconnected. This prevents the routine from exiting properly. When combined with the reconnect method introduced at 41b091f, this inadvertently caused "old" gpsSerialReader() routines to be orphaned without closing. This effectively created a resource leak every time a GPS re-initialization was called, and could cause ttyAMA0 misreads.
- This change adds a 2.5 sec serial port timeout to prevent indefinite blocking, and prevents additional gpsSerialReader() goroutines from being called until the old one returns.