### PR TITLE
Additional GPS compatibility improvements

### DIFF
--- a/main/ry835ai.go
+++ b/main/ry835ai.go
@@ -812,6 +812,8 @@ func processNMEALine(l string) bool {
 		if x[2] != "A" { // invalid fix
 			mySituation.quality = 0
 			return false
+		} else if mySituation.quality == 0 {
+			mySituation.quality = 1 // fallback option; indicate if the position fix is valid even if GGA or PUBX,00 aren't received
 		}
 
 		// Timestamp.
@@ -971,9 +973,9 @@ func gpsSerialReader() {
 
 		s := scanner.Text()
 		//fmt.Printf("Output: %s\n", s)
-		//if !(processNMEALine(s)) {
-		//	fmt.Printf("processNMEALine() exited early -- %s\n",s) //debug code. comment out before pushing to github
-		//}
+		if !(processNMEALine(s)) {
+			//	fmt.Printf("processNMEALine() exited early -- %s\n",s) //debug code. comment out before pushing to github
+		}
 	}
 	if err := scanner.Err(); err != nil {
 		log.Printf("reading standard input: %s\n", err.Error())


### PR DESCRIPTION
1. Cleaned up groundspeed detection routines to improve consistency of reporting. Groundspeed will now be reported any time a valid speed is parsed. True course will be updated only when groundspeed > 3 knots. Method is now consistently applied to all source message types (PUBX,00, VTG, and RMC).

2. Add missing `LastFixLocalTime` and `LastGroundFixTime` updates to VTG and RMC parsers to improve compatibility with older / generic NMEA receivers. A minimum of RMC + GSA are all that's needed to generate a valid 2D fix, including speed / track. 3D position still requires GGA messages.

3. Quality and position accuracy are now parsed prior to position reports, rather than in NMEA sentence order. This allows values to be updated prior to returning on a bad / missing position, and ensures that invalid lat/lon are not returned from PUBX messages. (Bad position messages didn't get passed to the GDL-90 output, but would show up on the web UI and JSON interfaces.)