### PR TITLE
Fix for Issue #79

### DIFF
--- a/init.d-stratux
+++ b/init.d-stratux
@@ -31,14 +31,16 @@ case "$1" in
 	log_daemon_msg "Starting $DESC" "$NAME"
 	echo powersave >/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 	# Check if we need to run an update.
-	UPDATE_SCRIPT=`ls -1t /root/update*.sh | head -1`
-	if [ -n "$UPDATE_SCRIPT" ] ; then
-		# Execute the script, remove it, then reboot.
-		echo
-		echo "Running update script ${UPDATE_SCRIPT}..."
-		sh ${UPDATE_SCRIPT}
-		rm -f $UPDATE_SCRIPT
-		reboot
+	if [ -e /root/update*.sh ] ; then
+		UPDATE_SCRIPT=`ls -1t /root/update*.sh | head -1`
+		if [ -n "$UPDATE_SCRIPT" ] ; then
+			# Execute the script, remove it, then reboot.
+			echo
+			echo "Running update script ${UPDATE_SCRIPT}..."
+			sh ${UPDATE_SCRIPT}
+			rm -f $UPDATE_SCRIPT
+			reboot
+		fi
 	fi
 	start-stop-daemon --start --background --oknodo --quiet --exec "$DAEMON_SBIN" \
 		--pidfile "$PIDFILE" --make-pidfile -- $DAEMON_OPTS >/dev/null

--- a/main/sdr.go
+++ b/main/sdr.go
@@ -331,7 +331,7 @@ func sdrWatcher() {
 	rUAT, err := regexp.Compile("str?a?t?u?x:978")
 	if err != nil {
 		rUAT = nil
-		log.Println("failed to compile ES regexp because %s", err.Error())
+		log.Println("failed to compile UAT regexp because %s", err.Error())
 	}
 
 	for {

--- a/main/sdr.go
+++ b/main/sdr.go
@@ -128,7 +128,7 @@ func (u *UAT) read() {
 
 func getPPM(serial string) int {
 	r, _ := regexp.Compile("str?a?t?u?x:\\d+:?(-?\\d*)")
-        arr := r.FindStringSubmatch(e.serial)
+        arr := r.FindStringSubmatch(serial)
 	if arr == nil {
 		return globalSettings.PPM
 	}

--- a/main/sdr.go
+++ b/main/sdr.go
@@ -126,29 +126,28 @@ func (u *UAT) read() {
 	}
 }
 
-func (e *ES) sdrConfig() (err error) {
-	log.Printf("===== ES Device Serial: %s =====\n", e.serial)
+func getPPM(serial string) int {
 	r, _ := regexp.Compile("str?a?t?u?x:\\d+:?(-?\\d*)")
-	arr := r.FindStringSubmatch(e.serial)
-	if ppm, err := strconv.Atoi(arr[1]); err != nil {
-		e.ppm = globalSettings.PPM
-	} else {
-		e.ppm = ppm
+        arr := r.FindStringSubmatch(e.serial)
+	if arr == nil {
+		return globalSettings.PPM
 	}
 
+        if ppm, err := strconv.Atoi(arr[1]); err != nil {
+                return globalSettings.PPM
+        } else {
+                return ppm
+        }
+}
+
+func (e *ES) sdrConfig() (err error) {
+	e.ppm = getPPM(e.serial)
 	return
 }
 
 func (u *UAT) sdrConfig() (err error) {
 	log.Printf("===== UAT Device name: %s =====\n", rtl.GetDeviceName(u.indexID))
-
-	r, _ := regexp.Compile("str?a?t?u?x:\\d+:?(-?\\d*)")
-	arr := r.FindStringSubmatch(u.serial)
-	if ppm, err := strconv.Atoi(arr[1]); err != nil {
-		u.ppm = globalSettings.PPM
-	} else {
-		u.ppm = ppm
-	}
+	u.ppm = getPPM(u.serial)
 
 	if u.dev, err = rtl.Open(u.indexID); err != nil {
 		log.Printf("\tUAT Open Failed...\n")


### PR DESCRIPTION
Allows for per-SDR PPM information.

- Legacy support for stratux:978 and stratux:1090 is preserved
- SDRs without a specified PPM get the globalSettings PPM as configured on the Settings page
- Because the serial number field is length-constrained, the preferred format with PPM is stx:freq:ppm, such as stx:1090:20. Per peepsnet's question below, negative PPMs are supported; example: stx:1090:-20
- The PPM parser and the frequency designator are independent entities. If you don't need to specify a frequency, pick any number other than 978 and 1090 (0 recommended), and Stratux will assign frequencies. (Per peepsnet's second question below). Example: stx:0:-20