### PR TITLE
Networking improvements

### DIFF
--- a/main/ry835ai.go
+++ b/main/ry835ai.go
@@ -1114,7 +1114,7 @@ func attitudeReaderSender() {
 		// Send, if valid.
 		//		if isGPSGroundTrackValid(), etc.
 
-		makeFFAHRSSimReport()
+		// makeFFAHRSSimReport() // simultaneous use of GDL90 and FFSIM not supported in FF 7.5.1 or later. Function definition will be kept for AHRS debugging and future workarounds.
 		makeAHRSGDL90Report()
 
 		mySituation.mu_Attitude.Unlock()


### PR DESCRIPTION
These changes improve network message efficiency, and are a possible solution to some of the disconnect problems described in #246.

Testing with both UAT replay and simulated traffic data indicates that wlan0 does not handle high IO rates well. Details of this testing will be posted to #246. Although I didn't determine whether this was a go issue, a wlan driver issue, or a hardware / power issue, I did find opportunities to optimize both the queued and nonqueued message senders.

- Traffic data is now passed to `sendGDL90()` in a single message for each call to sendTrafficUpdates(), rather than as sequential individual reports. This has no effect on timing of traffic data, but greatly improves IO efficiency. With two ForeFlight clients connected, I found that the wlan connection would drop / disconnect after ten minutes with 100 traffic targets, after two minutes with 250 targets, and after 15 seconds with 1000 targets (the last with a message rate of over 2000 messages/sec). With the traffic reports "batched", I was able to run for over five hours, with typical message rates of 32 IOPS.
- The message queue in `network.go` now batches 256 FIS-B messages before sending them to clients. This will improve stability when bringing devices out of standby; during one replay test before this was implemented, I observed rates of 800+ messages/sec as the queue emptied.
- The ForeFlight AHRS sender was commented out to save 10 messages/sec per channel.
- Fixed an issue where messages were not queuing for sleeping devices
- Added log status messages for message queue depth per IP address and port
- Added log status messages for IO messages / bytes; detailed (per second) status can be had by uncommenting network.go L422
- Added synthetic traffic routine to add an arbitrary number of targets to the traffic map for debug / testing purposes. The call in gen_gdl90.go is commented out in this PR, but can be enabled / compiled as needed by developers.