### PR TITLE
Traffic UI and other improvements

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -735,8 +735,10 @@ func updateStatus() {
 		globalStatus.GPS_solution = "3D GPS"
 	} else if mySituation.quality == 6 {
 		globalStatus.GPS_solution = "Dead Reckoning"
-	} else {
+	} else if mySituation.quality == 0 {
 		globalStatus.GPS_solution = "No Fix"
+	} else {
+		globalStatus.GPS_solution = "Unknown"
 	}
 
 	if !(globalStatus.GPS_connected) || !(isGPSConnected()) { // isGPSConnected looks for valid NMEA messages. GPS_connected is set by gpsSerialReader and will immediately fail on disconnected USB devices, or in a few seconds after "blocked" comms on ttyAMA0.
@@ -754,6 +756,8 @@ func updateStatus() {
 
 	// Update Uptime value
 	globalStatus.Uptime = int64(stratuxClock.Milliseconds)
+	globalStatus.UptimeClock = stratuxClock.Time
+	globalStatus.Clock = time.Now()
 }
 
 type ReplayWriter struct {
@@ -1031,6 +1035,8 @@ type status struct {
 	GPS_solution                               string
 	RY835AI_connected                          bool
 	Uptime                                     int64
+	Clock                                      time.Time
+	UptimeClock                                time.Time
 	CPUTemp                                    float32
 	NetworkDataMessagesSent                    uint64
 	NetworkDataMessagesSentNonqueueable        uint64

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -606,23 +606,25 @@ func heartBeatSender() {
 			sendGDL90(makeStratuxStatus(), false)
 			makeOwnshipReport()
 			makeOwnshipGeometricAltitudeReport()
-			/* --- debug code: traffic demo* --- /
-			/* Uncomment and compile to display huge number of artificial traffic targets
-			numTargets := uint32(1000)
-			hexCode := uint32(0xFF0000)
 
-			for i := uint32(0); i < numTargets; i++ {
-				tail := fmt.Sprintf("DEMO%d", i)
-				alt := float32((i*117%2000)*25 + 2000)
-				hdg := float64((i * 37) % 360)
-				spd := float64(100 + ((i*7)%61)*13)
+			// --- debug code: traffic demo ---
+			// Uncomment and compile to display large number of artificial traffic targets
+			/*
+				numTargets := uint32(40)
+				hexCode := uint32(0xFF0000)
 
-				updateDemoTraffic(i|hexCode, tail, alt, spd, hdg)
+				for i := uint32(0); i < numTargets; i++ {
+					tail := fmt.Sprintf("DEMO%d", i)
+					alt := float32((i*117%2000)*25 + 2000)
+					hdg := int32((i * 149) % 360)
+					spd := float64(50 + ((i*23)%13)*17)
 
-			}
+					updateDemoTraffic(i|hexCode, tail, alt, spd, hdg)
+
+				}
 
 			*/
-			/* ---end traffic demo code ---*/
+			// ---end traffic demo code ---
 			sendTrafficUpdates()
 			updateStatus()
 		case <-timerMessageStats.C:

--- a/main/ry835ai.go
+++ b/main/ry835ai.go
@@ -632,12 +632,12 @@ func processNMEALine(l string) bool {
 			} */
 
 			// field 2 is UTC time
-			if len(x[2]) < 9 {
+			if len(x[2]) < 7 {
 				return false
 			}
 			hr, err1 := strconv.Atoi(x[2][0:2])
 			min, err2 := strconv.Atoi(x[2][2:4])
-			sec, err3 := strconv.Atoi(x[2][4:6])
+			sec, err3 := strconv.ParseFloat(x[2][4:], 32)
 			if err1 != nil || err2 != nil || err3 != nil {
 				return false
 			}
@@ -647,8 +647,8 @@ func processNMEALine(l string) bool {
 
 			if len(x[3]) == 6 {
 				// Date of Fix, i.e 191115 =  19 November 2015 UTC  field 9
-				gpsTimeStr := fmt.Sprintf("%s %02d:%02d:%02d", x[3], hr, min, sec)
-				gpsTime, err := time.Parse("020106 15:04:05", gpsTimeStr)
+				gpsTimeStr := fmt.Sprintf("%s %02d:%02d:%06.3f", x[3], hr, min, sec)
+				gpsTime, err := time.Parse("020106 15:04:05.000", gpsTimeStr)
 				if err == nil {
 					mySituation.LastGPSTimeTime = stratuxClock.Time
 					// log.Printf("GPS time is: %s\n", gpsTime) //debug
@@ -839,8 +839,8 @@ func processNMEALine(l string) bool {
 
 		if len(x[9]) == 6 {
 			// Date of Fix, i.e 191115 =  19 November 2015 UTC  field 9
-			gpsTimeStr := fmt.Sprintf("%s %02d:%02d:%02d", x[9], hr, min, sec)
-			gpsTime, err := time.Parse("020106 15:04:05", gpsTimeStr)
+			gpsTimeStr := fmt.Sprintf("%s %02d:%02d:06.3f", x[9], hr, min, sec)
+			gpsTime, err := time.Parse("020106 15:04:05.000", gpsTimeStr)
 			if err == nil {
 				mySituation.LastGPSTimeTime = stratuxClock.Time
 				if time.Since(gpsTime) > 3*time.Second || time.Since(gpsTime) < -3*time.Second {

--- a/main/ry835ai.go
+++ b/main/ry835ai.go
@@ -34,10 +34,11 @@ type SituationData struct {
 	mu_GPS *sync.Mutex
 
 	// From GPS.
-	lastFixSinceMidnightUTC uint32
+	lastFixSinceMidnightUTC float32
 	Lat                     float32
 	Lng                     float32
 	quality                 uint8
+	HeightAboveEllipsoid    float32 // GPS height above WGS84 ellipsoid, ft. This is specified by the GDL90 protocol, but most EFBs use MSL altitude instead. HAE is about 70-100 ft below GPS MSL altitude over most of the US.
 	GeoidSep                float32 // geoid separation, ft, MSL minus HAE (used in altitude calculation)
 	Satellites              uint16  // satellites used in solution
 	SatellitesTracked       uint16  // satellites tracked (almanac data received)
@@ -51,6 +52,7 @@ type SituationData struct {
 	TrueCourse              uint16
 	GroundSpeed             uint16
 	LastGroundTrackTime     time.Time
+	LastGPSTimeTime         time.Time
 	LastNMEAMessage         time.Time // time valid NMEA message last seen
 
 	mu_Attitude *sync.Mutex
@@ -223,6 +225,8 @@ func initGPSSerial() bool {
 		p.Write(makeNMEACmd("PSRF103,05,00,01,01"))
 		// Disable GSV.
 		p.Write(makeNMEACmd("PSRF103,03,00,00,01"))
+
+		log.Printf("Finished writing SiRF GPS config to %s. Opening port to test connection.\n", device)
 	} else {
 		// Set 10Hz update. Little endian order.
 		p.Write(makeUBXCFG(0x06, 0x08, 6, []byte{0x64, 0x00, 0x01, 0x00, 0x01, 0x00}))
@@ -319,6 +323,8 @@ func initGPSSerial() bool {
 		p.Write(makeUBXCFG(0x06, 0x00, 20, cfg))
 		//	time.Sleep(100* time.Millisecond) // pause and wait for the GPS to finish configuring itself before closing / reopening the port
 		baudrate = 38400
+
+		log.Printf("Finished writing u-blox GPS config to %s. Opening port to test connection.\n", device)
 	}
 	p.Close()
 
@@ -332,7 +338,6 @@ func initGPSSerial() bool {
 	}
 
 	serialPort = p
-	log.Printf("GPS configuration complete\n")
 	return true
 }
 
@@ -482,17 +487,17 @@ func processNMEALine(l string) bool {
 			}
 
 			// field 2 = time
-			if len(x[2]) < 9 {
+			if len(x[2]) < 8 {
 				return false
 			}
 			hr, err1 := strconv.Atoi(x[2][0:2])
 			min, err2 := strconv.Atoi(x[2][2:4])
-			sec, err3 := strconv.Atoi(x[2][4:6])
+			sec, err3 := strconv.ParseFloat(x[2][4:], 32)
 			if err1 != nil || err2 != nil || err3 != nil {
 				return false
 			}
 
-			mySituation.lastFixSinceMidnightUTC = uint32((hr * 60 * 60) + (min * 60) + sec)
+			mySituation.lastFixSinceMidnightUTC = float32(3600*hr+60*min) + float32(sec)
 
 			// field 3-4 = lat
 
@@ -501,7 +506,7 @@ func processNMEALine(l string) bool {
 			}
 
 			hr, err1 = strconv.Atoi(x[3][0:2])
-			minf, err2 := strconv.ParseFloat(x[3][2:10], 32)
+			minf, err2 := strconv.ParseFloat(x[3][2:], 32)
 			if err1 != nil || err2 != nil {
 				return false
 			}
@@ -516,7 +521,7 @@ func processNMEALine(l string) bool {
 				return false
 			}
 			hr, err1 = strconv.Atoi(x[5][0:3])
-			minf, err2 = strconv.ParseFloat(x[5][3:11], 32)
+			minf, err2 = strconv.ParseFloat(x[5][3:], 32)
 			if err1 != nil || err2 != nil {
 				return false
 			}
@@ -532,7 +537,8 @@ func processNMEALine(l string) bool {
 			if err1 != nil {
 				return false
 			}
-			alt := float32(hae*3.28084) - mySituation.GeoidSep // convert to feet and offset by geoid separation
+			alt := float32(hae*3.28084) - mySituation.GeoidSep        // convert to feet and offset by geoid separation
+			mySituation.HeightAboveEllipsoid = float32(hae * 3.28084) // feet
 			mySituation.Alt = alt
 
 			mySituation.LastFixLocalTime = stratuxClock.Time
@@ -635,7 +641,7 @@ func processNMEALine(l string) bool {
 			if err1 != nil || err2 != nil || err3 != nil {
 				return false
 			}
-			mySituation.lastFixSinceMidnightUTC = uint32((hr * 60 * 60) + (min * 60) + sec)
+			mySituation.lastFixSinceMidnightUTC = float32(3600*hr+60*min) + float32(sec)
 
 			// field 3 is date
 
@@ -644,6 +650,7 @@ func processNMEALine(l string) bool {
 				gpsTimeStr := fmt.Sprintf("%s %02d:%02d:%02d", x[3], hr, min, sec)
 				gpsTime, err := time.Parse("020106 15:04:05", gpsTimeStr)
 				if err == nil {
+					mySituation.LastGPSTimeTime = stratuxClock.Time
 					// log.Printf("GPS time is: %s\n", gpsTime) //debug
 					if time.Since(gpsTime) > 3*time.Second || time.Since(gpsTime) < -3*time.Second {
 						setStr := gpsTime.Format("20060102 15:04:05.000") + " UTC"
@@ -656,6 +663,7 @@ func processNMEALine(l string) bool {
 					}
 				}
 			}
+
 		}
 
 		// otherwise parse the NMEA standard messages as a compatibility option for SIRF, generic NMEA, etc.
@@ -702,17 +710,17 @@ func processNMEALine(l string) bool {
 		mySituation.quality = uint8(q) // 1 = 3D GPS; 2 = DGPS (SBAS /WAAS)
 
 		// Timestamp.
-		if len(x[1]) < 9 {
+		if len(x[1]) < 7 {
 			return false
 		}
 		hr, err1 := strconv.Atoi(x[1][0:2])
 		min, err2 := strconv.Atoi(x[1][2:4])
-		sec, err3 := strconv.Atoi(x[1][4:6])
+		sec, err3 := strconv.ParseFloat(x[1][4:], 32)
 		if err1 != nil || err2 != nil || err3 != nil {
 			return false
 		}
 
-		mySituation.lastFixSinceMidnightUTC = uint32((hr * 60 * 60) + (min * 60) + sec)
+		mySituation.lastFixSinceMidnightUTC = float32(3600*hr+60*min) + float32(sec)
 
 		// Latitude.
 		if len(x[2]) < 4 {
@@ -783,6 +791,7 @@ func processNMEALine(l string) bool {
 			return false
 		}
 		mySituation.GeoidSep = float32(geoidSep * 3.28084) // Convert to feet.
+		mySituation.HeightAboveEllipsoid = mySituation.GeoidSep + mySituation.Alt
 
 		// Timestamp.
 		mySituation.LastFixLocalTime = stratuxClock.Time
@@ -803,7 +812,7 @@ func processNMEALine(l string) bool {
 		     D				mode field (nmea 2.3 and higher)
 		     *6A          The checksum data, always begins with *
 		*/
-		if len(x) < 12 {
+		if len(x) < 11 {
 			return false
 		}
 		mySituation.mu_GPS.Lock()
@@ -817,22 +826,23 @@ func processNMEALine(l string) bool {
 		}
 
 		// Timestamp.
-		if len(x[1]) < 9 {
+		if len(x[1]) < 7 {
 			return false
 		}
 		hr, err1 := strconv.Atoi(x[1][0:2])
 		min, err2 := strconv.Atoi(x[1][2:4])
-		sec, err3 := strconv.Atoi(x[1][4:6])
+		sec, err3 := strconv.ParseFloat(x[1][4:], 32)
 		if err1 != nil || err2 != nil || err3 != nil {
 			return false
 		}
-		mySituation.lastFixSinceMidnightUTC = uint32((hr * 60 * 60) + (min * 60) + sec)
+		mySituation.lastFixSinceMidnightUTC = float32(3600*hr+60*min) + float32(sec)
 
 		if len(x[9]) == 6 {
 			// Date of Fix, i.e 191115 =  19 November 2015 UTC  field 9
 			gpsTimeStr := fmt.Sprintf("%s %02d:%02d:%02d", x[9], hr, min, sec)
 			gpsTime, err := time.Parse("020106 15:04:05", gpsTimeStr)
 			if err == nil {
+				mySituation.LastGPSTimeTime = stratuxClock.Time
 				if time.Since(gpsTime) > 3*time.Second || time.Since(gpsTime) < -3*time.Second {
 					setStr := gpsTime.Format("20060102 15:04:05.000") + " UTC"
 					log.Printf("setting system time to: '%s'\n", setStr)
@@ -1132,6 +1142,10 @@ func isGPSValid() bool {
 
 func isGPSGroundTrackValid() bool {
 	return stratuxClock.Since(mySituation.LastGroundTrackTime) < 15*time.Second
+}
+
+func isGPSClockValid() bool {
+	return stratuxClock.Since(mySituation.LastGPSTimeTime) < 15*time.Second
 }
 
 func isAHRSValid() bool {

--- a/main/traffic.go
+++ b/main/traffic.go
@@ -82,8 +82,8 @@ type TrafficInfo struct {
 
 	Vvel int16
 
-	Tail string
-
+	Tail        string
+	Timestamp   time.Time
 	Last_seen   time.Time
 	Last_source uint8
 }
@@ -367,6 +367,8 @@ func parseDownlinkReport(s string) {
 	//OK.
 	//	fmt.Printf("tisb_site_id %d, utc_coupled %t\n", tisb_site_id, utc_coupled)
 
+	ti.Timestamp = time.Now() // TODO: Parse from downlink message.
+
 	ti.Last_source = TRAFFIC_SOURCE_UAT
 	ti.Last_seen = stratuxClock.Time
 
@@ -549,6 +551,8 @@ func esListen() {
 				}
 			}
 
+			ti.Timestamp = time.Now() // TODO: Parse from x[8] and x[9]
+
 			// Update "last seen" (any type of message, as long as the ICAO addr can be parsed).
 			ti.Last_source = TRAFFIC_SOURCE_1090ES
 			ti.Last_seen = stratuxClock.Time
@@ -608,9 +612,10 @@ func updateDemoTraffic(icao uint32, tail string, relAlt float32, gs float64, off
 	ti.Alt = int32(mySituation.Alt + relAlt)
 	ti.Track = uint16(hdg)
 	ti.Speed = uint16(gs)
-	ti.Speed_valid = true
+	ti.Speed_valid = false
 	ti.Vvel = 0
 	ti.Tail = tail // "DEMO1234"
+	ti.Timestamp = time.Now()
 	ti.Last_seen = stratuxClock.Time
 	ti.Last_source = 1
 

--- a/main/traffic.go
+++ b/main/traffic.go
@@ -237,6 +237,11 @@ func parseDownlinkReport(s string) {
 	// OK.
 	//	fmt.Printf("%d, %d, %06X\n", msg_type, ti.addr_type, ti.Icao_addr)
 
+	// TO-DO: Parse time from downlink message
+	if !isGPSClockValid() {
+		// this is where we'd update the RPi clock if GPS isn't connected
+	}
+
 	nic := uint8(frame[11]) & 15 //TODO: Meaning?
 
 	raw_lat := (uint32(frame[4]) << 15) | (uint32(frame[5]) << 7) | (uint32(frame[6]) >> 1)

--- a/main/traffic.go
+++ b/main/traffic.go
@@ -246,11 +246,6 @@ func parseDownlinkReport(s string) {
 	// OK.
 	//	fmt.Printf("%d, %d, %06X\n", msg_type, ti.addr_type, ti.Icao_addr)
 
-	// TO-DO: Parse time from downlink message
-	if !isGPSClockValid() {
-		// this is where we'd update the RPi clock if GPS isn't connected
-	}
-
 	nic := uint8(frame[11]) & 15 //TODO: Meaning?
 
 	raw_lat := (uint32(frame[4]) << 15) | (uint32(frame[5]) << 7) | (uint32(frame[6]) >> 1)
@@ -381,7 +376,7 @@ func parseDownlinkReport(s string) {
 	//OK.
 	//	fmt.Printf("tisb_site_id %d, utc_coupled %t\n", tisb_site_id, utc_coupled)
 
-	ti.Timestamp = time.Now() // TODO: Parse from downlink message.
+	ti.Timestamp = time.Now()
 
 	ti.Last_source = TRAFFIC_SOURCE_UAT
 	ti.Last_seen = stratuxClock.Time
@@ -566,7 +561,7 @@ func esListen() {
 				}
 			}
 
-			ti.Timestamp = time.Now() // TODO: Parse from x[8] and x[9]
+			ti.Timestamp = time.Now()
 
 			// Update "last seen" (any type of message, as long as the ICAO addr can be parsed).
 			ti.Last_source = TRAFFIC_SOURCE_1090ES

--- a/main/traffic.go
+++ b/main/traffic.go
@@ -620,7 +620,7 @@ func updateDemoTraffic(icao uint32, tail string, relAlt float32, gs float64, off
 	ti.Alt = int32(mySituation.Alt + relAlt)
 	ti.Track = uint16(hdg)
 	ti.Speed = uint16(gs)
-	if hdg > 180 && hdg < 195 {
+	if hdg > 100 && hdg < 150 {
 		ti.Speed_valid = false
 	} else {
 		ti.Speed_valid = true
@@ -629,7 +629,7 @@ func updateDemoTraffic(icao uint32, tail string, relAlt float32, gs float64, off
 	ti.Tail = tail // "DEMO1234"
 	ti.Timestamp = time.Now()
 	ti.Last_seen = stratuxClock.Time
-	ti.Age = 0
+	ti.Age = hdg / 1000
 	ti.Last_source = 1
 	if icao%7 == 1 { // make some of the traffic UAT sourced
 		ti.Last_source = 2

--- a/web/plates/js/status.js
+++ b/web/plates/js/status.js
@@ -54,7 +54,14 @@ function StatusCtrl($rootScope, $scope, $state, $http, $interval) {
 			$scope.GPS_satellites_seen = status.GPS_satellites_seen;
 			$scope.GPS_solution = status.GPS_solution;
 			$scope.RY835AI_connected = status.RY835AI_connected;
-
+			var tempClock = new Date(Date.parse(status.Clock));
+			var clockString = tempClock.toUTCString();
+			$scope.Clock = clockString;
+			var tempLocalClock = new Date;
+			$scope.LocalClock = tempLocalClock.toUTCString();
+			$scope.SecondsFast = (tempClock-tempLocalClock)/1000;
+			
+			
 			var uptime = status.Uptime;
 			if (uptime != undefined) {
 				var up_s = parseInt((uptime / 1000) % 60),

--- a/web/plates/js/status.js
+++ b/web/plates/js/status.js
@@ -59,7 +59,7 @@ function StatusCtrl($rootScope, $scope, $state, $http, $interval) {
 			$scope.Clock = clockString;
 			var tempLocalClock = new Date;
 			$scope.LocalClock = tempLocalClock.toUTCString();
-			$scope.SecondsFast = (tempClock-tempLocalClock)/1000;
+			$scope.SecondsFast = (Math.round(tempClock-tempLocalClock)/1000).toFixed(2);
 			
 			
 			var uptime = status.Uptime;

--- a/web/plates/js/traffic.js
+++ b/web/plates/js/traffic.js
@@ -7,6 +7,9 @@ function TrafficCtrl($rootScope, $scope, $state, $http, $interval) {
 	$scope.$parent.helppage = 'plates/traffic-help.html';
 	$scope.data_list = [];
 
+
+	
+	
 	function utcTimeString(epoc) {
 		var time = "";
 		var val;
@@ -42,8 +45,10 @@ function TrafficCtrl($rootScope, $scope, $state, $http, $interval) {
 		var s = Math.round(obj.Speed / 5) * 5;
 		if (obj.Speed_valid) {
 			new_traffic.speed = s.toString();
+			new_traffic.heading = Math.round(obj.Track / 5) * 5;
 		} else {
 			new_traffic.speed = "---";
+			new_traffic.heading = "---";
 		}
 		new_traffic.vspeed = Math.round(obj.Vvel / 100) * 100
 		new_traffic.age = Date.parse(obj.Last_seen);

--- a/web/plates/js/traffic.js
+++ b/web/plates/js/traffic.js
@@ -52,25 +52,11 @@ function TrafficCtrl($rootScope, $scope, $state, $http, $interval) {
 		new_traffic.vspeed = Math.round(obj.Vvel / 100) * 100
 		var timestamp = Date.parse(obj.Timestamp);
 		new_traffic.time = utcTimeString(timestamp);
-		new_traffic.age = obj.Age;
+		new_traffic.age = (Math.round(obj.Age * 10)/10).toFixed(1);
 		new_traffic.src = obj.Last_source; // 1=ES, 2=UAT
 		// return new_aircraft;
 	}
-/*
-	function getStratuxTime() {
-		// Simple GET request example (note: response is asynchronous)
-		$http.get(URL_STATUS_GET).
-		then(function (response) {
-			globalStatus = angular.fromJson(response.data);
-			$scope.UptimeClock = globalStatus.UptimeClock;
-			$scope.Clock = globalStatus.Clock;
-			$scope.LocalClock = new Date();
-		}, function (response) {
-			// nop
-		});
-	};
-*/	
-	
+
 
 	function connect($scope) {
 		if (($scope === undefined) || ($scope === null))
@@ -155,15 +141,14 @@ function TrafficCtrl($rootScope, $scope, $state, $http, $interval) {
 		
 		
 
-	
-	// perform cleanup every 60 seconds
+	// perform cleanup every 10 seconds
 	var clearStaleTraffic = $interval(function () {
-		// remove stale aircraft = anything more than 180 seconds without an update
+		// remove stale aircraft = anything more than 60 seconds without an update
 		var dirty = false;
-		var cutoff = Date.now() - (180 * 1000);
+		var cutoff =60;
 
 		for (var i = len = $scope.data_list.length; i > 0; i--) {
-			if ($scope.data_list[i - 1].age < cutoff) {
+			if ($scope.data_list[i - 1].age > cutoff) {
 				$scope.data_list.splice(i - 1, 1);
 				dirty = true;
 			}
@@ -172,7 +157,7 @@ function TrafficCtrl($rootScope, $scope, $state, $http, $interval) {
 			$scope.raw_data = "";
 			$scope.$apply();
 		}
-	}, (1000 * 60), 0, false);
+	}, (1000 * 10), 0, false);
 
 
 	$state.get('traffic').onEnter = function () {

--- a/web/plates/js/traffic.js
+++ b/web/plates/js/traffic.js
@@ -41,7 +41,6 @@ function TrafficCtrl($rootScope, $scope, $state, $http, $interval) {
 		new_traffic.lon = dmsString(obj.Lng);
 		var n = Math.round(obj.Alt / 25) * 25;
 		new_traffic.alt = n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-		new_traffic.heading = Math.round(obj.Track / 5) * 5;
 		var s = Math.round(obj.Speed / 5) * 5;
 		if (obj.Speed_valid) {
 			new_traffic.speed = s.toString();
@@ -51,7 +50,7 @@ function TrafficCtrl($rootScope, $scope, $state, $http, $interval) {
 			new_traffic.heading = "---";
 		}
 		new_traffic.vspeed = Math.round(obj.Vvel / 100) * 100
-		new_traffic.age = Date.parse(obj.Last_seen);
+		new_traffic.age = Date.parse(obj.Timestamp);
 		new_traffic.time = utcTimeString(new_traffic.age);
 		new_traffic.src = obj.Last_source; // 1=ES, 2=UAT
 		// return new_aircraft;

--- a/web/plates/js/traffic.js
+++ b/web/plates/js/traffic.js
@@ -50,8 +50,9 @@ function TrafficCtrl($rootScope, $scope, $state, $http, $interval) {
 			new_traffic.heading = "---";
 		}
 		new_traffic.vspeed = Math.round(obj.Vvel / 100) * 100
-		new_traffic.age = Date.parse(obj.Timestamp);
-		new_traffic.time = utcTimeString(new_traffic.age);
+		var timestamp = Date.parse(obj.Timestamp);
+		new_traffic.time = utcTimeString(timestamp);
+		new_traffic.age = obj.Age;
 		new_traffic.src = obj.Last_source; // 1=ES, 2=UAT
 		// return new_aircraft;
 	}

--- a/web/plates/js/traffic.js
+++ b/web/plates/js/traffic.js
@@ -113,7 +113,7 @@ function TrafficCtrl($rootScope, $scope, $state, $http, $interval) {
 
 	// perform cleanup every 60 seconds
 	var clearStaleTraffic = $interval(function () {
-		// remove stail aircraft = anything more than 180 seconds without and update
+		// remove stale aircraft = anything more than 180 seconds without an update
 		var dirty = false;
 		var cutoff = Date.now() - (180 * 1000);
 

--- a/web/plates/js/traffic.js
+++ b/web/plates/js/traffic.js
@@ -55,6 +55,21 @@ function TrafficCtrl($rootScope, $scope, $state, $http, $interval) {
 		new_traffic.src = obj.Last_source; // 1=ES, 2=UAT
 		// return new_aircraft;
 	}
+/*
+	function getStratuxTime() {
+		// Simple GET request example (note: response is asynchronous)
+		$http.get(URL_STATUS_GET).
+		then(function (response) {
+			globalStatus = angular.fromJson(response.data);
+			$scope.UptimeClock = globalStatus.UptimeClock;
+			$scope.Clock = globalStatus.Clock;
+			$scope.LocalClock = new Date();
+		}, function (response) {
+			// nop
+		});
+	};
+*/	
+	
 
 	function connect($scope) {
 		if (($scope === undefined) || ($scope === null))
@@ -86,8 +101,10 @@ function TrafficCtrl($rootScope, $scope, $state, $http, $interval) {
 		};
 
 		socket.onmessage = function (msg) {
+			
+			
 			console.log('Received traffic update.')
-
+			
 			var message = JSON.parse(msg.data);
 			$scope.raw_data = angular.toJson(msg.data, true);
 
@@ -111,6 +128,33 @@ function TrafficCtrl($rootScope, $scope, $state, $http, $interval) {
 		};
 	}
 
+	var getClock = $interval(function () {
+		$http.get(URL_STATUS_GET).
+		then(function (response) {
+			globalStatus = angular.fromJson(response.data);
+				
+			var tempClock = new Date(Date.parse(globalStatus.Clock));
+			var clockString = tempClock.toUTCString();
+			$scope.Clock = clockString;
+
+			var tempUptimeClock = new Date(Date.parse(globalStatus.UptimeClock));
+			var uptimeClockString = tempUptimeClock.toUTCString();
+			$scope.UptimeClock = uptimeClockString;
+
+			var tempLocalClock = new Date;
+			$scope.LocalClock = tempLocalClock.toUTCString();
+			$scope.SecondsFast = (tempClock-tempLocalClock)/1000;
+						
+		}, function (response) {
+			// nop
+		});
+	}, 500, 0, false);
+		
+		
+		
+		
+
+	
 	// perform cleanup every 60 seconds
 	var clearStaleTraffic = $interval(function () {
 		// remove stale aircraft = anything more than 180 seconds without an update

--- a/web/plates/status-help.html
+++ b/web/plates/status-help.html
@@ -1,17 +1,14 @@
 <div class="section text-left help-page">
     <p>The <strong>Status</strong> page provides an overview of your Stratux device.</p>
-    <p>The current state of you device is shown at th top - <code>Connected</code> in green or <code>Disconected</code>in red.</p>
+    <p>The current state of you device is shown at the top - <code>Connected</code> in green or <code>Disconected</code>in red.</p>
 
-    <p>Depending on the hardware you have installed in your Stratux, you will have status for the following:</p>
+    <p>Depending on the hardware you have installed in your Stratux, status messages will be shown for the following:</p>
     <ul class="list-simple">
-        <li><strong>SDR</strong> (software defined radio) dongle tuned to 978Mhz for UAT (universal access transceiver) traffic and weather</li>
-        <li><strong>SDR</strong> (software defined radio) dongle tuned to 1090Mhz for ES (extended squitter) traffic</li>
-        <li><strong>GPS</strong> the RY835AI module receiving GPS data from satellites</li>
-        <li><strong>AHRS</strong> the RY835AI module generating attitude data from its pressure sensor, gyroscope, accelerometer, and magnetometer.</li>
+        <li><strong>Messages</strong> is the number of messages received by the UAT (978 MHz) and 1090 MHz radios. "Current" is the 60-second rolling total for each receiver; "Peak" is the maximum 60-second total. The 1090 total includes all 1090 MHz Mode S messages received, including all-call and TCAS interrogations that do not carry ADS-B position information. If a UAT radio is receiving uplinks from one or more ground-based transceivers (GBT), this will be indicated under <strong>UAT Towers</strong>, with more details available on the Towers page.</li>
+        <li><strong>GPS</strong> indicates the connection status of any attached GPS receivers. Reported data includes the type of position solution, the number of satellites used in that solution, the number of satellites being received, and the number of satellites tracked in the GPS almanac data. Position and accuracy details can be viewed on the <strong>GPS/AHRS</strong> page.</li>
+        <li><strong>AHRS</strong> indicates whether the pressure sensor and gyro on an RY835AI or similar 10-axis module are connected and enabled. If connected, attitude and pressure altitude can be viewed on the <strong>GPS/AHRS</strong> page.</li>
     </ul>
-    <p class="text-warning">NOTE: This page only shows devices you have installed and turned on (via the <strong>Settings</strong> page.</p>
+    <p class="text-warning">Devices must be manually enabled on the <strong>Settings</strong> page.</p>
 
-    <p>The <strong>Messages</strong> section gives you details for messages received. There are statistics for the rolling average for the past 60 seconds as well as the peak average.</p>
-    <p>For GPS and AHRS you can view the number of satellites being received and if AHRS is configured and operating.</p>
-    <p>The <strong>Status</strong> page also gives you an indication of how long your Stratux devices has been operating since you turned it on, as well as reporting the on-board temperature sensor of the Raspberry Pi.</p>
+    <p>Additional statistics include the number of detected software-defined radios (SDRs), number of current DHCP network clients, uptime, temperature of the Raspberry Pi CPU, and the current clock settings on both the Raspberry Pi and the device / browser used to view this page.</p>
 </div>

--- a/web/plates/status.html
+++ b/web/plates/status.html
@@ -72,31 +72,32 @@
 				</div>
 				<div class="row"><span class="col-xs-1">&nbsp;</span></div>
 				<div class="separator"></div>
+				
 				<div class="row">
-					<div class="col-sm-6 label_adj">
-						<strong class="col-xs-5">Uptime:</strong>
+					<div class="col-sm-4 label_adj">
+						<span class="col-xs-5"><strong>Uptime:</strong></span>
 						<span class="col-xs-7">{{Uptime}}</span>
 					</div>
-					<div class="col-sm-6 label_adj">
-						<strong class="col-xs-5">CPU Temp:</strong>
+					<div class="col-sm-4 label_adj">
+						<span class="col-xs-5"><strong>CPU Temp:</strong></span>
 						<span class="col-xs-7">{{CPUTemp}}</span>
 					</div>
 				</div>
+
 				<div class="separator"></div>
 				<div class="row">
 					<div class="col-sm-4 label_adj">
-						<strong class="col-xs-5">Stratux Clock:</strong>
-						<span class="col-xs-7">{{Clock}}</span>
+						<span class="col-xs-4"><strong>Stratux Clock:</strong></span>
+						<span class="col-xs-8">{{Clock}}</span>
 					</div>
 					<div class="col-sm-4 label_adj">
-						<strong class="col-xs-5">Device Clock:</strong>
-						<span class="col-xs-7">{{LocalClock}}</span>
+						<span class="col-xs-4"><strong>Device Clock:</strong></span>
+						<span class="col-xs-8">{{LocalClock}}</span>
 					</div>
 					<div class="col-sm-4 label_adj">
-						<strong class="col-xs-5">Difference [sec]:</strong>
-						<span class="col-xs-7">{{SecondsFast}}</span>
+						<span class="col-xs-4"><strong>Difference:</strong></span>
+						<span class="col-xs-8">{{SecondsFast}} sec</span>
 					</div>
-					
 				</div>
 			</div>
 		</div>

--- a/web/plates/status.html
+++ b/web/plates/status.html
@@ -82,6 +82,22 @@
 						<span class="col-xs-7">{{CPUTemp}}</span>
 					</div>
 				</div>
+				<div class="separator"></div>
+				<div class="row">
+					<div class="col-sm-4 label_adj">
+						<strong class="col-xs-5">Stratux Clock:</strong>
+						<span class="col-xs-7">{{Clock}}</span>
+					</div>
+					<div class="col-sm-4 label_adj">
+						<strong class="col-xs-5">Device Clock:</strong>
+						<span class="col-xs-7">{{LocalClock}}</span>
+					</div>
+					<div class="col-sm-4 label_adj">
+						<strong class="col-xs-5">Difference [sec]:</strong>
+						<span class="col-xs-7">{{SecondsFast}}</span>
+					</div>
+					
+				</div>
 			</div>
 		</div>
 	</div>

--- a/web/plates/traffic-help.html
+++ b/web/plates/traffic-help.html
@@ -1,18 +1,18 @@
 <div class="section text-left help-page">
-	<p>The <strong>Traffic</strong> page provides a list of recent aircraft received. Each time a new aircraft is reported, it is added to the list. Each time a new report is received for an existing aircraft, the list is updated. If a report for an aircraft is not received for 3 minutes (180 seconds), the aircraft is removed from the list.</p>
+	<p>The <strong>Traffic</strong> page provides a list of all aircraft position reports received within the last 60 seconds. Each time a new aircraft is reported, it is added to the list. Each time a new report is received for an existing aircraft, the list is updated. If a report for an aircraft has not been received within the last 60 seconds, the aircraft is removed from the list.</p>
 	<p>For each aircraft, the list includes the following details:</p>
 	<ul class="list-simple">
-		<li><strong>Flight</strong> - either the aircraft tail number / ATC call sign or the ICAO number. When the ICAO number is used, it is displayed in grey.
+		<li><strong>Flight</strong> is aircraft tail number / call sign (when available) or the ICAO 24-bit code. When the ICAO code is used, it is displayed in gray.
 			<ul class="list-simple">
-				<li><span class="label traffic-style1">1090 ES</span> is displayed with a light blue background.</li>
-				<li><span class="label traffic-style2">978 UAT</span> is displayed with a light tan background.</li>
+				<li><span class="label traffic-style1">1090 ES</span> traffic is displayed with a light blue background.</li>
+				<li><span class="label traffic-style2">978 UAT</span> traffic is displayed with a light tan background.</li>
 			</ul>
 		</li>
-		<li><strong>Speed</strong> - current reported speed in knots</li>
-		<li><strong>Altitude</strong> - current reported altitude and climb/decent rate if when not reporting level flight</li>
-		<li><strong>Heading</strong> - direction of reported flight</li>
-		<li><strong>Location</strong> - the latitude and longitude reported</li>
-		<li><strong>Time</strong> - the last time (UTC) a report was received</li>
+		<li><strong>Speed</strong> - Reported ground speed, rounded to the nearest 5 knots. Invalid or missing values are shown as '---'.</li>
+		<li><strong>Altitude</strong> - Reported pressure altitude, feet MSL. Climb or descent rate is also shown if not in level flight.</li>
+		<li><strong>Course</strong> - Reported true course, rounded to the nearest 5°. Invalid or missing values are shown as '---'</li>
+		<li><strong>Location</strong> - Reported latitude and longitude, DD° mm' ss''.</li>
+		<li><strong>Age</strong> - Age of the last traffic report, seconds.</li>
 	</ul>
-	<p class="text-warning">NOTE: When this page becomes active (aka it is selected from the menu) it will display only new traffic. Older traffic and existing traffic will not appear until their next report.</p>
+	<p><strong>Stratux Clock</strong> and <strong>Device Clock</strong> are the UTC timestamps reported by the Stratux and by the web browser on your mobile device, respectively.</p>
 </div>

--- a/web/plates/traffic.html
+++ b/web/plates/traffic.html
@@ -11,12 +11,12 @@
 					<span class="col-xs-3"><strong>Flight</strong></span>
 					<span class="col-xs-3 text-right">Speed</span>
 					<span class="col-xs-3 text-right">Altitude</span><span class="col-xs-1 col-padding-shift-right">&nbsp;</span>
-					<span class="col-xs-2 text-right">Hdg</span>
+					<span class="col-xs-2 text-right">Course</span>
 				</div>
 				<div class="col-sm-6">
 					<span class="col-xs-2">&nbsp;</span>
 					<span class="col-xs-7">Location</span>
-					<span class="col-xs-3 text-right">Age [sec]</span>
+					<span class="col-xs-3 text-right">Age</span>
 				</div>
 			</div>
 
@@ -44,24 +44,22 @@
 				</div>
 			</div>
 		</div>
+		<div class="panel-body traffic-footer">
+			<div class="separator"></div>
+			<div class="row">
+				<div class="col-sm-6 label_adj">
+					<span class="col-xs-4"><strong>Stratux Clock:</strong></span>
+					<span class="col-xs-8">{{Clock}}</span>
+				</div>
+				<div class="col-sm-6 label_adj">
+					<span class="col-xs-4"><strong>Device Clock:</strong></span>
+					<span class="col-xs-8">{{LocalClock}}</span>
+				</div>
+			</div>
+		</div>
 	</div>
 </div>
-				<div class="separator"></div>
-				<div class="row">
-					<div class="col-sm-4 label_adj">
-						<strong class="col-xs-5">Stratux Clock:</strong>
-						<span class="col-xs-7">{{Clock}}</span>
-					</div>
-					<div class="col-sm-4 label_adj">
-						<strong class="col-xs-5">Device Clock:</strong>
-						<span class="col-xs-7">{{LocalClock}}</span>
-					</div>
-					<div class="col-sm-4 label_adj">
-						<strong class="col-xs-5">Uptime Clock</strong>
-						<span class="col-xs-7">{{UptimeClock}}</span>
-					</div>
-					
-				</div>
+
 
 <!--
 <div class="col-sm-12">

--- a/web/plates/traffic.html
+++ b/web/plates/traffic.html
@@ -45,6 +45,23 @@
 		</div>
 	</div>
 </div>
+				<div class="separator"></div>
+				<div class="row">
+					<div class="col-sm-4 label_adj">
+						<strong class="col-xs-5">Stratux Clock:</strong>
+						<span class="col-xs-7">{{Clock}}</span>
+					</div>
+					<div class="col-sm-4 label_adj">
+						<strong class="col-xs-5">Device Clock:</strong>
+						<span class="col-xs-7">{{LocalClock}}</span>
+					</div>
+					<div class="col-sm-4 label_adj">
+						<strong class="col-xs-5">Uptime Clock</strong>
+						<span class="col-xs-7">{{UptimeClock}}</span>
+					</div>
+					
+				</div>
+
 <!--
 <div class="col-sm-12">
 	<div class="panel panel-default">

--- a/web/plates/traffic.html
+++ b/web/plates/traffic.html
@@ -16,7 +16,7 @@
 				<div class="col-sm-6">
 					<span class="col-xs-2">&nbsp;</span>
 					<span class="col-xs-7">Location</span>
-					<span class="col-xs-3 text-right">Time Last Seen</span>
+					<span class="col-xs-3 text-right">Age [sec]</span>
 				</div>
 			</div>
 
@@ -39,7 +39,8 @@
 				<div class="col-sm-6">
 					<span class="col-xs-2">&nbsp;</span>
 					<span class="col-xs-7">{{aircraft.lat}} {{aircraft.lon}}</span>
-					<span class="col-xs-3 text-right">{{aircraft.time}}</span>
+					<!--<span class="col-xs-3 text-right">{{aircraft.time}}</span>-->
+					<span class="col-xs-3 text-right">{{aircraft.age}}</span>
 				</div>
 			</div>
 		</div>

--- a/web/plates/traffic.html
+++ b/web/plates/traffic.html
@@ -16,7 +16,7 @@
 				<div class="col-sm-6">
 					<span class="col-xs-2">&nbsp;</span>
 					<span class="col-xs-7">Location</span>
-					<span class="col-xs-3 text-right">Time</span>
+					<span class="col-xs-3 text-right">Time Last Seen</span>
 				</div>
 			</div>
 


### PR DESCRIPTION
Fixes for #251 and #254.

- Traffic "last seen" time is now changed to a traffic age, set by the internal Stratux `monotonic` timer.
- traffic.go JSON calls updated to refresh all traffic once per second, even if postion hasn't been updated.
- New ti.Timestamp and ti.Age variables added to traffic.go
- Timeout for sending GDL90 traffic message reduced to 6 seconds. Traffic will remain in internal database and on web UI for 60 seconds.
- Minor GPS improvements related to time parsing
- Added clock to web UI status page.
- Update status UI to reflect new features added over the past few months