### PR TITLE
Bug fixes for traffic UI and setting GPS time

### DIFF
--- a/main/ry835ai.go
+++ b/main/ry835ai.go
@@ -839,7 +839,7 @@ func processNMEALine(l string) bool {
 
 		if len(x[9]) == 6 {
 			// Date of Fix, i.e 191115 =  19 November 2015 UTC  field 9
-			gpsTimeStr := fmt.Sprintf("%s %02d:%02d:06.3f", x[9], hr, min, sec)
+			gpsTimeStr := fmt.Sprintf("%s %02d:%02d:%06.3f", x[9], hr, min, sec)
 			gpsTime, err := time.Parse("020106 15:04:05.000", gpsTimeStr)
 			if err == nil {
 				mySituation.LastGPSTimeTime = stratuxClock.Time

--- a/web/plates/js/traffic.js
+++ b/web/plates/js/traffic.js
@@ -143,12 +143,12 @@ function TrafficCtrl($rootScope, $scope, $state, $http, $interval) {
 
 	// perform cleanup every 10 seconds
 	var clearStaleTraffic = $interval(function () {
-		// remove stale aircraft = anything more than 60 seconds without an update
+		// remove stale aircraft = anything more than 59 seconds without an update
 		var dirty = false;
-		var cutoff =60;
+		var cutoff =59;
 
 		for (var i = len = $scope.data_list.length; i > 0; i--) {
-			if ($scope.data_list[i - 1].age > cutoff) {
+			if ($scope.data_list[i - 1].age >= cutoff) {
 				$scope.data_list.splice(i - 1, 1);
 				dirty = true;
 			}


### PR DESCRIPTION
- Fix a bug in #259 where traffic targets 59.x seconds old are not removed from web UI
- Fix a malformed time string when setting date / time from the RMC GPS message
