### PR TITLE
use standalone httpd service / move stratux services to port 8080

### DIFF
--- a/image/spindle/wheezy-stage4
+++ b/image/spindle/wheezy-stage4
@@ -37,8 +37,14 @@ setup_stratux() {
 echo "**** STRATUX SETUP *****"
 
   ssh_in_to_qemu chroot /mnt sh -l -ex - <<\EOF
-#general
-apt-get install -y screen
+
+#http server
+apt-get install -y lighttpd
+ln -s /var/log /var/www/logs
+makedir -p /var/logs/stratux
+chmod o+x /var/logs/stratux
+echo 'dir-listing.activate = "enable"' >> /etc/lighttpd/lighttpd.conf
+echo 'server.follow-symlink = "enable"' >> /etc/lighttpd/lighttpd.conf
 #wifi
 apt-get install -y hostapd isc-dhcp-server
 #troubleshooting

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -38,7 +38,7 @@ import (
 const (
 	configLocation      = "/etc/stratux.conf"
 	indexFilename       = "/var/log/stratux/LOGINDEX"
-	managementAddr      = ":80"
+	managementAddr      = ":8080"
 	debugLog            = "/var/log/stratux.log"
 	maxDatagramSize     = 8192
 	maxUserMsgQueueSize = 25000 // About 10MB per port per connected client.

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -310,7 +310,7 @@ func managementInterface() {
 	weatherUpdate = NewUIBroadcaster()
 	trafficUpdate = NewUIBroadcaster()
 
-	http.HandleFunc("/", defaultServer)
+	// http.HandleFunc("/", defaultServer)
 	http.Handle("/logs/", http.StripPrefix("/logs/", http.FileServer(http.Dir("/var/log"))))
 	http.HandleFunc("/status",
 		func(w http.ResponseWriter, req *http.Request) {

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -1,5 +1,5 @@
 // application constants
-var URL_HOST_BASE 		= window.location.hostname;
+var URL_HOST_BASE 		= window.location.hostname+":8080";
 var URL_SETTINGS_GET 	= "http://"	+ URL_HOST_BASE + "/getSettings";
 var URL_SETTINGS_SET 	= "http://"	+ URL_HOST_BASE + "/setSettings";
 var URL_GPS_GET 		= "http://"	+ URL_HOST_BASE + "/getSituation";


### PR DESCRIPTION
this removes gen_gdl90 from service the basic WebUI. gen_gdl90 still provides its web services and websockets - now on port 8080.

`http://192.168.10.1` will return the Stratus WebUI
`http://192.168.10.1:8080/getSettings` will return the stratux settings JSON

Spindle will install `lighttpd`, add a symlink to access logs, and then enable support for directory lists and smlinks so the log page still works.
