### PR TITLE
Show traffic source (ADS-B vs TIS-B) in web UI

### DIFF
--- a/web/css/main.css
+++ b/web/css/main.css
@@ -152,15 +152,31 @@
 }
 
 .paperairplane_left,
-.traffic-style1 {
+.traffic-style1,
+.traffic-style10,
+.traffic-style11 {
 	color: #000000;
 	background-color: cornflowerblue;
 }
 
+.traffic-style12,
+.traffic-style13 {
+	color: #000000;
+	background-color: skyblue;
+}
+
 .paperairplane_right,
-.traffic-style2 {
+.traffic-style2,
+.traffic-style20,
+.traffic-style21 {
 	color: #000000;
 	background-color: darkkhaki
+}
+
+.traffic-style22,
+.traffic-style23 {
+	color: #000000;
+	background-color: khaki
 }
 
 .icon-red {

--- a/web/plates/js/traffic.js
+++ b/web/plates/js/traffic.js
@@ -35,6 +35,11 @@ function TrafficCtrl($rootScope, $scope, $state, $http, $interval) {
 
 	function setAircraft(obj, new_traffic) {
 		new_traffic.icao_int = obj.Icao_addr;
+		new_traffic.addr_type = obj.Addr_type;
+		new_traffic.addr_symb ='\u2708';
+		if (new_traffic.addr_type > 1) {
+			new_traffic.addr_symb ='\u{1F4E1}';
+		}
 		new_traffic.icao = obj.Icao_addr.toString(16).toUpperCase();
 		new_traffic.tail = obj.Tail;
 		new_traffic.lat = dmsString(obj.Lat);

--- a/web/plates/traffic.html
+++ b/web/plates/traffic.html
@@ -24,8 +24,8 @@
 				<div class="separator"></div>
 				<div class="col-sm-6">
 					<span class="col-xs-3">
-						<span ng-show="aircraft.tail" ng-class="'label traffic-style'+aircraft.src"><strong>{{aircraft.tail}}</strong></span>
-						<span ng-hide="aircraft.tail" ng-class="'label traffic-style'+aircraft.src"><strong class="text-muted">{{aircraft.icao}}</strong></span>
+						<span ng-show="aircraft.tail" ng-class="'label traffic-style'+aircraft.src+aircraft.addr_type"><strong>{{aircraft.addr_symb}}&nbsp;{{aircraft.tail}}</strong></span>
+						<span ng-hide="aircraft.tail" ng-class="'label traffic-style'+aircraft.src+aircraft.addr_type"><strong class="text-muted">{{aircraft.addr_symb}}&nbsp;{{aircraft.icao}}</strong></span>
 					</span>
 
 					<span class="col-xs-3 text-right">{{aircraft.speed}} KTS</span>


### PR DESCRIPTION
Requested at https://redd.it/46hmso

This update passes `ti.Addr_type` to the web UI to support showing whether traffic messages originated from ADS-B air-to-air broadcasts, or from TIS-B ground-to-air broadcasts. Currently, this is supported only for UAT traffic, as the dump1090 output on port 30003 does not pass this status. 

Traffic reports originating at the GBTs are indicated with a lighter highlight color and a satellite dish symbol. Airborne reports use the existing color and get an airplane symbol.

![image](https://cloud.githubusercontent.com/assets/14127245/13167953/9a069bf4-d69d-11e5-8f57-d09e21c4ff49.png)