### PR TITLE
Enhancements to dual-PPM (minor bug fix, web status)

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1021,6 +1021,7 @@ type status struct {
 	Version                                    string
 	Devices                                    uint32
 	Connected_Users                            uint
+	Connected_Devices			   uint
 	UAT_messages_last_minute                   uint
 	uat_products_last_minute                   map[string]uint32
 	UAT_messages_max                           uint

--- a/main/sdr.go
+++ b/main/sdr.go
@@ -404,6 +404,23 @@ func sdrWatcher() {
 						id = 1
 					}
 				}
+
+				/* Address #275. If both devices are nil, but
+			 	 * id 1 matches the rUAT string, we need to
+				 * force the UAT to id 1, so that UAT doesn't
+				 * consume a flexible id 0 and leave ES bound
+				 * to an undesired, fixed 978.
+				 * A parallel fix is not installed in the ES
+				 * code, because both cases are already handled:
+				 * id 0 flex, id 1 1090, then 0 bound to UAT
+				 * id 1 flex, id 0 1090, then 0 bound to ES
+				 */
+				if UATDev == nil && ESDev == nil && rUAT {
+					_, _, serial, err := rtl.GetDeviceUsbStrings(1)
+					if err == nil && rUAT.MatchSerial(serial) {
+						id = 1
+					}
+				}
 			}
 
 			if UATDev == nil {

--- a/main/sdr.go
+++ b/main/sdr.go
@@ -415,9 +415,9 @@ func sdrWatcher() {
 				 * id 0 flex, id 1 1090, then 0 bound to UAT
 				 * id 1 flex, id 0 1090, then 0 bound to ES
 				 */
-				if UATDev == nil && ESDev == nil && rUAT {
+				if UATDev == nil && ESDev == nil && rUAT != nil {
 					_, _, serial, err := rtl.GetDeviceUsbStrings(1)
-					if err == nil && rUAT.MatchSerial(serial) {
+					if err == nil && rUAT.MatchString(serial) {
 						id = 1
 					}
 				}

--- a/web/plates/js/status.js
+++ b/web/plates/js/status.js
@@ -44,6 +44,7 @@ function StatusCtrl($rootScope, $scope, $state, $http, $interval) {
 			$scope.Version = status.Version;
 			$scope.Devices = status.Devices;
 			$scope.Connected_Users = status.Connected_Users;
+			$scope.Connected_Devices = status.Connected_Devices;
 			$scope.UAT_messages_last_minute = status.UAT_messages_last_minute;
 			// $scope.UAT_products_last_minute = JSON.stringify(status.UAT_products_last_minute);
 			$scope.UAT_messages_max = status.UAT_messages_max;

--- a/web/plates/status.html
+++ b/web/plates/status.html
@@ -16,8 +16,8 @@
 						<span class="col-xs-7">{{Connected_Users}}</span>
 					</div>
 					<div class="col-sm-6 label_adj">
-						<strong class="col-xs-5">SDR devices:</strong>
-						<span class="col-xs-7">{{Devices}}</span>
+						<strong class="col-xs-7">SDR active / total:</strong>
+						<span class="col-xs-5">{{Connected_Devices}} / {{Devices}}</span>
 					</div>
 				</div>
 				<div class="separator"></div>


### PR DESCRIPTION
- Skipping the stratux serial check when the other device is already bound. This prevents a misconfiguration (two SDRs with stratux:1090, for example) from blocking the second frequency from coming online.
- Fix a special-case bug where id 0 is flexible and id 1 is hard-wired to UAT. Comments explain why the same special-case need not be applied to ES hard-wiring.
- Added logging of serial numbers and PPMs per my comment on issue #275
- Added SDRs active count to status page