### PR TITLE
Change to be more specific in choosing update file

### DIFF
--- a/init.d-stratux
+++ b/init.d-stratux
@@ -31,8 +31,8 @@ case "$1" in
 	log_daemon_msg "Starting $DESC" "$NAME"
 	echo powersave >/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 	# Check if we need to run an update.
-	if [ -e /root/update*.sh ] ; then
-		UPDATE_SCRIPT=`ls -1t /root/update*.sh | head -1`
+	if [ -e /root/update*stratux*v*.sh ] ; then
+		UPDATE_SCRIPT=`ls -1t /root/update*stratux*v*.sh | head -1`
 		if [ -n "$UPDATE_SCRIPT" ] ; then
 			# Execute the script, remove it, then reboot.
 			echo


### PR DESCRIPTION
This change might prevent another update*.sh script from being executed since it is just looking in the root directory for the latest file with the word update. 

This would require naming the update the same update\*stratux\*v*.sh
i.e.: update-stratux-v0.7b4-f98a8d58c6.sh

Just a bit more safety...