### PR TITLE
Dump1090 improvements. Overhauled traffic parsing. UAT groundspeed and air/ground status bug fixes.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = git://github.com/cyoung/linux-mpu9150
 [submodule "dump1090"]
 	path = dump1090
-	url = https://github.com/MalcolmRobb/dump1090
+	url = https://github.com/AvSquirrel/dump1090

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -606,8 +606,8 @@ func heartBeatSender() {
 
 			// --- debug code: traffic demo ---
 			// Uncomment and compile to display large number of artificial traffic targets
-			/*
-				numTargets := uint32(40)
+			
+				numTargets := uint32(1)
 				hexCode := uint32(0xFF0000)
 
 				for i := uint32(0); i < numTargets; i++ {
@@ -620,7 +620,7 @@ func heartBeatSender() {
 
 				}
 
-			*/
+			
 			// ---end traffic demo code ---
 			sendTrafficUpdates()
 			updateStatus()
@@ -848,10 +848,6 @@ func parseInput(buf string) ([]byte, uint16) {
 		isUplink = true
 	}
 
-	if s[0] == '-' {
-		parseDownlinkReport(s)
-	}
-
 	var thisSignalStrength int
 
 	if isUplink && len(x) >= 3 {
@@ -868,6 +864,11 @@ func parseInput(buf string) ([]byte, uint16) {
 		}
 	}
 
+	if s[0] == '-' {
+		parseDownlinkReport(s, int32(thisSignalStrength))
+	}
+	
+	
 	s = s[1:]
 	msglen := len(s) / 2
 

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -850,7 +850,7 @@ func parseInput(buf string) ([]byte, uint16) {
 
 	var thisSignalStrength int
 
-	if /*isUplink* &&*/ len(x) >= 3 {
+	if /*isUplink &&*/ len(x) >= 3 {
 		// See if we can parse out the signal strength.
 		ss := x[2]
 		//log.Printf("x[2] = %s\n",ss)
@@ -858,7 +858,7 @@ func parseInput(buf string) ([]byte, uint16) {
 			ssStr := ss[3:]
 			if ssInt, err := strconv.Atoi(ssStr); err == nil {
 				thisSignalStrength = ssInt
-				if ssInt > maxSignalStrength {
+				if ssInt > isUplink && maxSignalStrength { // only look at uplinks; ignore ADS-B and TIS-B/ADS-R messages
 					maxSignalStrength = ssInt
 				}
 			} else {

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -606,8 +606,8 @@ func heartBeatSender() {
 
 			// --- debug code: traffic demo ---
 			// Uncomment and compile to display large number of artificial traffic targets
-			
-				numTargets := uint32(1)
+			/*
+				numTargets := uint32(18)
 				hexCode := uint32(0xFF0000)
 
 				for i := uint32(0); i < numTargets; i++ {
@@ -619,7 +619,7 @@ func heartBeatSender() {
 					updateDemoTraffic(i|hexCode, tail, alt, spd, hdg)
 
 				}
-
+			*/
 			
 			// ---end traffic demo code ---
 			sendTrafficUpdates()

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -858,7 +858,7 @@ func parseInput(buf string) ([]byte, uint16) {
 			ssStr := ss[3:]
 			if ssInt, err := strconv.Atoi(ssStr); err == nil {
 				thisSignalStrength = ssInt
-				if ssInt > isUplink && maxSignalStrength { // only look at uplinks; ignore ADS-B and TIS-B/ADS-R messages
+				if isUplink && (ssInt > maxSignalStrength) { // only look at uplinks; ignore ADS-B and TIS-B/ADS-R messages
 					maxSignalStrength = ssInt
 				}
 			} else {

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -850,9 +850,10 @@ func parseInput(buf string) ([]byte, uint16) {
 
 	var thisSignalStrength int
 
-	if isUplink && len(x) >= 3 {
+	if /*isUplink* &&*/ len(x) >= 3 {
 		// See if we can parse out the signal strength.
 		ss := x[2]
+		//log.Printf("x[2] = %s\n",ss)
 		if strings.HasPrefix(ss, "ss=") {
 			ssStr := ss[3:]
 			if ssInt, err := strconv.Atoi(ssStr); err == nil {
@@ -860,6 +861,8 @@ func parseInput(buf string) ([]byte, uint16) {
 				if ssInt > maxSignalStrength {
 					maxSignalStrength = ssInt
 				}
+			} else {
+				//log.Printf("Error was %s\n",err.Error())
 			}
 		}
 	}

--- a/main/traffic.go
+++ b/main/traffic.go
@@ -67,44 +67,44 @@ const (
 	TARGET_TYPE_ADSR      = 2
 	TARGET_TYPE_TISB      = 3
 	// Assign next type to UAT messages with address qualifier == 2
-	// (code corresponds to and UAT GBT targets with Mode S addresses.. 
+	// (code corresponds to and UAT GBT targets with Mode S addresses..
 	// for we'll treat them as ADS-R in the UI. Might be able to assign as TYPE_ADSR if we see a proper emitter category and NIC > 7.
-	TARGET_TYPE_TISB_S    = 4
+	TARGET_TYPE_TISB_S = 4
 )
 
 type TrafficInfo struct {
-	Icao_addr        uint32
-	Tail             string
-	Emitter_category uint8 // Formatted using GDL90 standard, e.g. in a Mode ES report, A7 becomes 0x07, B0 becomes 0x08, etc. 
-	OnGround         bool // Air-ground status. On-ground is "true".
-	Addr_type        uint8 // UAT address qualifier. Used by GDL90 format, so translations for ES TIS-B/ADS-R are needed.
-	TargetType       uint8 // types decribed in const above
-	SignalLevel		 int32 // Arbitrary signal level reported by dump1090 and dump978. 
-	Position_valid      bool	// set when position report received. Unset after n seconds? (To-do)
-	Lat                 float32 // decimal degrees, north positive
-	Lng                 float32 // decimal degrees, east positive
-	Alt                 int32 // Pressure altitude, feet
-	GnssDiffFromBaroAlt int32 // GNSS altitude above WGS84 datum. Reported in TC 20-22 messages
-	AltIsGNSS           bool  // Pressure alt = 0; GNSS alt = 1
-	NIC                 int   // Navigation Integrity Category.
-	NACp                int   // Navigation Accuracy Category for Position.
-	Track               uint16 // degrees true
-	Speed               uint16 // knots
-	Speed_valid         bool  // set when speed report received.
-	Vvel                int16  // feet per minute
-	Timestamp        time.Time // timestamp of traffic message, UTC
+	Icao_addr           uint32
+	Tail                string
+	Emitter_category    uint8     // Formatted using GDL90 standard, e.g. in a Mode ES report, A7 becomes 0x07, B0 becomes 0x08, etc.
+	OnGround            bool      // Air-ground status. On-ground is "true".
+	Addr_type           uint8     // UAT address qualifier. Used by GDL90 format, so translations for ES TIS-B/ADS-R are needed.
+	TargetType          uint8     // types decribed in const above
+	SignalLevel         int32     // Arbitrary signal level reported by dump1090 and dump978.
+	Position_valid      bool      // set when position report received. Unset after n seconds? (To-do)
+	Lat                 float32   // decimal degrees, north positive
+	Lng                 float32   // decimal degrees, east positive
+	Alt                 int32     // Pressure altitude, feet
+	GnssDiffFromBaroAlt int32     // GNSS altitude above WGS84 datum. Reported in TC 20-22 messages
+	AltIsGNSS           bool      // Pressure alt = 0; GNSS alt = 1
+	NIC                 int       // Navigation Integrity Category.
+	NACp                int       // Navigation Accuracy Category for Position.
+	Track               uint16    // degrees true
+	Speed               uint16    // knots
+	Speed_valid         bool      // set when speed report received.
+	Vvel                int16     // feet per minute
+	Timestamp           time.Time // timestamp of traffic message, UTC
 
 	// Parameters starting at 'Age' are calculated after message receipt.
 	// Mode S transmits position and track in separate messages, and altitude can also be
 	// received from interrogations.
-	Age              float64   // seconds ago traffic last seen
-	Last_seen        time.Time // time of last position update, relative to Stratux startup. Used for timing out expired data.
-	Last_alt         time.Time // time of last altitude update, relative to Stratux startup
-	Last_speed       time.Time // time of last velocity / track update, relative to Stratux startup
-	Last_source      uint8     // last SDR on which this target was observed
-	ExtrapolatedPosition bool // TO-DO: True if Stratux is "coasting" the target from last known position.
-	Bearing	float64  // TO-DO: Bearing in degrees true to traffic from ownship
-	Distance float64 // TO-DO: Distance to traffic from ownship
+	Age                  float64   // seconds ago traffic last seen
+	Last_seen            time.Time // time of last position update, relative to Stratux startup. Used for timing out expired data.
+	Last_alt             time.Time // time of last altitude update, relative to Stratux startup
+	Last_speed           time.Time // time of last velocity / track update, relative to Stratux startup
+	Last_source          uint8     // last SDR on which this target was observed
+	ExtrapolatedPosition bool      // TO-DO: True if Stratux is "coasting" the target from last known position.
+	Bearing              float64   // TO-DO: Bearing in degrees true to traffic from ownship
+	Distance             float64   // TO-DO: Distance to traffic from ownship
 }
 
 type dump1090Data struct {
@@ -116,7 +116,7 @@ type dump1090Data struct {
 	SBS_MsgType         int // type of SBS message (used in "old" 1090 parsing)
 	SignalLevel         int // 0-255
 	Tail                *string
-	Squawk              *int      // 12-bit squawk code in octal format
+	Squawk              *int // 12-bit squawk code in octal format
 	Emitter_category    *int
 	OnGround            *bool
 	Lat                 *float32
@@ -124,13 +124,13 @@ type dump1090Data struct {
 	Position_valid      bool
 	NACp                *int
 	Alt                 *int
-	AltIsGNSS           bool // 
+	AltIsGNSS           bool   //
 	GnssDiffFromBaroAlt *int16 // GNSS height above baro altitude in feet; valid range is -3125 to 3125. +/- 3138 indicates larger difference.
 	Vvel                *int16
 	Speed_valid         bool
 	Speed               *uint16
 	Track               *uint16
-	Timestamp        time.Time // time traffic last seen, UTC
+	Timestamp           time.Time // time traffic last seen, UTC
 }
 
 var traffic map[uint32]TrafficInfo
@@ -150,7 +150,19 @@ func sendTrafficUpdates() {
 	defer trafficMutex.Unlock()
 	cleanupOldEntries()
 	var msg []byte
+	log.Printf("List of all aircraft being tracked:\n")
+	log.Printf("===================================\n")
 	for icao, ti := range traffic { // TO-DO: Limit number of aircraft in traffic message. ForeFlight 7.5 chokes at ~1000-2000 messages depending on iDevice RAM. Practical limit likely around ~500 aircraft without filtering.
+
+		// DEBUG: Print the list of all tracked targets to the log each second
+		s_out, err := json.Marshal(ti)
+		if err != nil {
+			log.Printf("Error generating output: %s\n", err.Error())
+		} else {
+			log.Printf("%X => %s\n", ti.Icao_addr, string(s_out))
+		}
+		// end of debug block
+
 		ti.Age = stratuxClock.Since(ti.Last_seen).Seconds()
 		traffic[icao] = ti
 		//log.Printf("Traffic age of %X is %f seconds\n",icao,ti.Age)
@@ -224,7 +236,7 @@ func makeTrafficReportMsg(ti TrafficInfo) []byte {
 	}
 	msg[11] = byte((alt & 0xFF0) >> 4) // Altitude.
 	msg[12] = byte((alt & 0x00F) << 4)
-	
+
 	// "m" field. Lower four bits define indicator bits:
 	// - - 0 0   "tt" (msg[17]) is not valid
 	// - - 0 1   "tt" is true track
@@ -234,22 +246,22 @@ func makeTrafficReportMsg(ti TrafficInfo) []byte {
 	// - 1 - -   Report is extrapolated
 	// 0 - - -   On ground
 	// 1 - - -   Airborne
-	
+
 	// Define tt type / validity
 	if ti.Speed_valid {
-		msg[12] = msg[12] | 0x01  // assume true track
+		msg[12] = msg[12] | 0x01 // assume true track
 	}
-	
+
 	if ti.ExtrapolatedPosition {
 		msg[12] = msg[12] | 0x04
 	}
-	
+
 	if !ti.OnGround {
 		msg[12] = msg[12] | 0x08 // Airborne.
 	}
 
 	// Position containment / navigational accuracy
-	msg[13] = ((byte(ti.NIC) << 4) & 0xF0) | ((byte(ti.NACp) & 0x0F))
+	msg[13] = ((byte(ti.NIC) << 4) & 0xF0) | (byte(ti.NACp) & 0x0F)
 
 	// Horizontal velocity (speed).
 
@@ -290,10 +302,10 @@ func parseDownlinkReport(s string, signalLevel int32) {
 	msg_type := (uint8(frame[0]) >> 3) & 0x1f
 	addr_type := uint8(frame[0]) & 0x07
 	icao_addr := (uint32(frame[1]) << 16) | (uint32(frame[2]) << 8) | uint32(frame[3])
-	
+
 	trafficMutex.Lock()
 	defer trafficMutex.Unlock()
-		
+
 	// Retrieve previous information on this ICAO code.
 	if val, ok := traffic[icao_addr]; ok { // if we've already seen it, copy it in to do updates as it may contain some useful information like "tail" from 1090ES.
 		ti = val
@@ -304,9 +316,9 @@ func parseDownlinkReport(s string, signalLevel int32) {
 		ti.Icao_addr = icao_addr
 		ti.ExtrapolatedPosition = false
 	}
-	
+
 	ti.Addr_type = addr_type
-	
+
 	// Parse tail number, if available.
 	if msg_type == 1 || msg_type == 3 { // Need "MS" portion of message.
 		base40_alphabet := string("0123456789ABCDEFGHIJKLMNOPQRTSUVWXYZ  ..")
@@ -334,7 +346,7 @@ func parseDownlinkReport(s string, signalLevel int32) {
 			ti.Tail = "u" + ti.Tail
 		}
 	}
-		
+
 	// Extract emitter category.
 	if msg_type == 1 || msg_type == 3 {
 		v := (uint16(frame[17]) << 8) | (uint16(frame[18]))
@@ -345,11 +357,11 @@ func parseDownlinkReport(s string, signalLevel int32) {
 	//	fmt.Printf("%d, %d, %06X\n", msg_type, ti.Addr_type, ti.Icao_addr)
 
 	ti.NIC = int(frame[11] & 0x0F)
-		
-	if ((msg_type == 1) || (msg_type == 3)) { // Since NACp is passed with normal UATreports, no need to use our ES hack.
-		ti.NACp = int((frame[25] >> 4) & 0x0F) 
+
+	if (msg_type == 1) || (msg_type == 3) { // Since NACp is passed with normal UATreports, no need to use our ES hack.
+		ti.NACp = int((frame[25] >> 4) & 0x0F)
 	}
-		
+
 	ti.SignalLevel = signalLevel
 
 	if ti.Addr_type == 0 {
@@ -360,11 +372,11 @@ func parseDownlinkReport(s string, signalLevel int32) {
 		ti.TargetType = TARGET_TYPE_ADSR
 	} else if ti.Addr_type == 2 {
 		ti.TargetType = TARGET_TYPE_TISB_S
-		if ((ti.NIC >= 7) && (ti.Emitter_category > 0)) { // If NIC is sufficiently and emitter type is transmitted, we'll assume it's ADS-R.
+		if (ti.NIC >= 7) && (ti.Emitter_category > 0) { // If NIC is sufficiently and emitter type is transmitted, we'll assume it's ADS-R.
 			ti.TargetType = TARGET_TYPE_ADSR
 		}
 	}
-	
+
 	raw_lat := (uint32(frame[4]) << 15) | (uint32(frame[5]) << 7) | (uint32(frame[6]) >> 1)
 	raw_lon := ((uint32(frame[6]) & 0x01) << 23) | (uint32(frame[7]) << 15) | (uint32(frame[8]) << 7) | (uint32(frame[9]) >> 1)
 
@@ -401,7 +413,7 @@ func parseDownlinkReport(s string, signalLevel int32) {
 	ti.Alt = alt
 	ti.AltIsGNSS = alt_geo
 	ti.Last_alt = stratuxClock.Time
-	
+
 	//OK.
 	//	fmt.Printf("%d, %t, %f, %f, %t, %d\n", nic, position_valid, lat, lng, alt_geo, alt)
 
@@ -485,7 +497,7 @@ func parseDownlinkReport(s string, signalLevel int32) {
 	if ti.Speed_valid {
 		ti.Last_speed = stratuxClock.Time
 	}
-	
+
 	//OK.
 	//	fmt.Printf("ns_vel %d, ew_vel %d, track %d, speed_valid %t, speed %d, vvel_geo %t, vvel %d\n", ns_vel, ew_vel, track, speed_valid, speed, vvel_geo, vvel)
 
@@ -504,7 +516,7 @@ func parseDownlinkReport(s string, signalLevel int32) {
 	//	fmt.Printf("tisb_site_id %d, utc_coupled %t\n", tisb_site_id, utc_coupled)
 
 	ti.Timestamp = time.Now()
-		
+
 	ti.Last_source = TRAFFIC_SOURCE_UAT
 
 	traffic[ti.Icao_addr] = ti
@@ -549,55 +561,55 @@ func esListen() {
 			thisMsg.TimeReceived = stratuxClock.Time
 			thisMsg.Data = []byte(buf)
 			MsgLog = append(MsgLog, thisMsg)
-						
+
 			icao := uint32(newTi.Icao_addr)
 			var ti TrafficInfo
-			
+
 			trafficMutex.Lock()
-		
+
 			// Retrieve previous information on this ICAO code.
 			if val, ok := traffic[icao]; ok { // if we've already seen it, copy it in to do updates
 				ti = val
 				log.Printf("Existing target %X imported for ES update\n", icao)
 			} else {
-				log.Printf("New target %X created for ES update\n",newTi.Icao_addr)
+				log.Printf("New target %X created for ES update\n", newTi.Icao_addr)
 				ti.Last_seen = stratuxClock.Time // need to initialize to current stratuxClock so it doesn't get cut before we have a chance to populate a position message
 				ti.Icao_addr = icao
 				ti.ExtrapolatedPosition = false
 			}
-			
+
 			ti.SignalLevel = int32(newTi.SignalLevel)
-			
+
 			// generate human readable summary of message types for debug
 			// TO-DO: Use for ES message statistics?
 			/*
-			var s1 string
-			if newTi.DF == 17 {
-				s1 = "ADS-B"
-			}
-			if newTi.DF == 18 {
-				s1 = "ADS-R / TIS-B"
-			}
+				var s1 string
+				if newTi.DF == 17 {
+					s1 = "ADS-B"
+				}
+				if newTi.DF == 18 {
+					s1 = "ADS-R / TIS-B"
+				}
 
-			if newTi.DF == 4 || newTi.DF == 20 {
-				s1 = "Surveillance, Alt. Reply"
-			}
+				if newTi.DF == 4 || newTi.DF == 20 {
+					s1 = "Surveillance, Alt. Reply"
+				}
 
-			if newTi.DF == 5 || newTi.DF == 21 {
-				s1 = "Surveillance, Ident. Reply"
-			}
+				if newTi.DF == 5 || newTi.DF == 21 {
+					s1 = "Surveillance, Ident. Reply"
+				}
 
-			if newTi.DF == 11 {
-				s1 = "All-call Reply"
-			}
+				if newTi.DF == 11 {
+					s1 = "All-call Reply"
+				}
 
-			if newTi.DF == 0 {
-				s1 = "Short Air-Air Surv."
-			}
+				if newTi.DF == 0 {
+					s1 = "Short Air-Air Surv."
+				}
 
-			if newTi.DF == 16 {
-				s1 = "Long Air-Air Surv."
-			}
+				if newTi.DF == 16 {
+					s1 = "Long Air-Air Surv."
+				}
 			*/
 			//log.Printf("Mode S message from icao=%X, DF=%02d, CA=%02d, TC=%02d (%s)\n", ti.Icao_addr, newTi.DF, newTi.CA, newTi.TypeCode, s1)
 
@@ -605,16 +617,16 @@ func esListen() {
 			// and Mode S messages (DF=0, DF = 4, and DF = 20).
 
 			ti.AltIsGNSS = newTi.AltIsGNSS
-			
+
 			if newTi.Alt != nil {
 				ti.Alt = int32(*newTi.Alt)
 				ti.Last_alt = stratuxClock.Time
 			}
-			
+
 			if newTi.GnssDiffFromBaroAlt != nil {
 				ti.GnssDiffFromBaroAlt = int32(*newTi.GnssDiffFromBaroAlt) // we can estimate pressure altitude from GNSS height with this parameter!
 			}
-			
+
 			// Position updates are provided only by ES messages (DF=17 and DF=18; multiple TCs)
 			if newTi.Position_valid { // i.e. DF17 or DF18 message decoded successfully by dump1090
 				valid_position := true
@@ -672,8 +684,8 @@ func esListen() {
 					ti.Speed = speed
 					ti.Speed_valid = true
 					ti.Last_speed = stratuxClock.Time // only update "last seen" data on position updates
-				} 
-			} else if (((newTi.DF == 17) || (newTi.DF == 18)) && (newTi.TypeCode == 19)) { // invalid speed on velocity message only
+				}
+			} else if ((newTi.DF == 17) || (newTi.DF == 18)) && (newTi.TypeCode == 19) { // invalid speed on velocity message only
 				ti.Speed_valid = false
 			}
 
@@ -711,20 +723,20 @@ func esListen() {
 					nic = 11
 				}
 				ti.NIC = nic
-				
-				if ((ti.NACp < 7) && (ti.NACp < ti.NIC)) {
+
+				if (ti.NACp < 7) && (ti.NACp < ti.NIC) {
 					ti.NACp = ti.NIC // initialize to NIC, since NIC is sent with every position report, and not all emitters report NACp.
 				}
 			}
-	
+
 			if newTi.NACp != nil {
 				ti.NACp = *newTi.NACp
 			}
-									
+
 			if newTi.Emitter_category != nil {
-					ti.Emitter_category = uint8(*newTi.Emitter_category) // validate dump1090 on live traffic
-			} 
-			
+				ti.Emitter_category = uint8(*newTi.Emitter_category) // validate dump1090 on live traffic
+			}
+
 			// Set the target type. DF=18 messages are sent by ground station, so we look at CA
 			// (repurposed to Control Field in DF18) to determine if it's ADS-R or TIS-B.
 			if newTi.DF == 17 {
@@ -734,15 +746,15 @@ func esListen() {
 				if newTi.CA == 6 {
 					ti.TargetType = TARGET_TYPE_ADSR
 					ti.Addr_type = 2
-				} else if (newTi.CA == 2) { // 2 = TIS-B with ICAO address, 5 = TIS-B without ICAO address
+				} else if newTi.CA == 2 { // 2 = TIS-B with ICAO address, 5 = TIS-B without ICAO address
 					ti.TargetType = TARGET_TYPE_TISB
 					ti.Addr_type = 2
-				} else if (newTi.CA == 5) {
+				} else if newTi.CA == 5 {
 					ti.TargetType = TARGET_TYPE_TISB
 					ti.Addr_type = 3
 				}
 			}
-			
+
 			if newTi.OnGround != nil { // DF=11 messages don't report "on ground" status so we need to check for valid values.
 				ti.OnGround = bool(*newTi.OnGround)
 			}
@@ -761,14 +773,14 @@ func esListen() {
 			ti.Timestamp = newTi.Timestamp // only update "last seen" data on position updates
 			ti.Last_source = TRAFFIC_SOURCE_1090ES
 			/*
-			s_out, err := json.Marshal(ti)
-			if err != nil {
-				log.Printf("Error generating output: %s\n", err.Error())
-			} else {
-				log.Printf("%X (DF%d) => %s\n", ti.Icao_addr, newTi.DF, string(s_out))
-			}
+				s_out, err := json.Marshal(ti)
+				if err != nil {
+					log.Printf("Error generating output: %s\n", err.Error())
+				} else {
+					log.Printf("%X (DF%d) => %s\n", ti.Icao_addr, newTi.DF, string(s_out))
+				}
 			*/
-			
+
 			traffic[ti.Icao_addr] = ti // Update information on this ICAO code.
 			registerTrafficUpdate(ti)
 			seenTraffic[ti.Icao_addr] = true // Mark as seen.

--- a/main/traffic.go
+++ b/main/traffic.go
@@ -67,44 +67,46 @@ const (
 	TARGET_TYPE_ADSR      = 2
 	TARGET_TYPE_TISB      = 3
 	// Assign next type to UAT messages with address qualifier == 2
-	// (code corresponds to and UAT GBT targets with Mode S addresses..
+	// (code corresponds to and UAT GBT targets with Mode S addresses.. 
 	// for we'll treat them as ADS-R in the UI. Might be able to assign as TYPE_ADSR if we see a proper emitter category and NIC > 7.
-	TARGET_TYPE_TISB_S = 4
+	TARGET_TYPE_TISB_S    = 4
 )
 
 type TrafficInfo struct {
-	Icao_addr           uint32
-	Tail                string
-	Emitter_category    uint8     // Formatted using GDL90 standard, e.g. in a Mode ES report, A7 becomes 0x07, B0 becomes 0x08, etc.
-	OnGround            bool      // Air-ground status. On-ground is "true".
-	Addr_type           uint8     // UAT address qualifier. Used by GDL90 format, so translations for ES TIS-B/ADS-R are needed.
-	TargetType          uint8     // types decribed in const above
-	SignalLevel         int32     // Arbitrary signal level reported by dump1090 and dump978.
-	Position_valid      bool      // set when position report received. Unset after n seconds? (To-do)
-	Lat                 float32   // decimal degrees, north positive
-	Lng                 float32   // decimal degrees, east positive
-	Alt                 int32     // Pressure altitude, feet
-	GnssDiffFromBaroAlt int32     // GNSS altitude above WGS84 datum. Reported in TC 20-22 messages
-	AltIsGNSS           bool      // Pressure alt = 0; GNSS alt = 1
-	NIC                 int       // Navigation Integrity Category.
-	NACp                int       // Navigation Accuracy Category for Position.
-	Track               uint16    // degrees true
-	Speed               uint16    // knots
-	Speed_valid         bool      // set when speed report received.
-	Vvel                int16     // feet per minute
-	Timestamp           time.Time // timestamp of traffic message, UTC
+	Icao_addr        uint32
+	Tail             string
+	Emitter_category uint8 // Formatted using GDL90 standard, e.g. in a Mode ES report, A7 becomes 0x07, B0 becomes 0x08, etc. 
+	OnGround         bool // Air-ground status. On-ground is "true".
+	Addr_type        uint8 // UAT address qualifier. Used by GDL90 format, so translations for ES TIS-B/ADS-R are needed.
+	TargetType       uint8 // types decribed in const above
+	SignalLevel		 int32 // Arbitrary signal level reported by dump1090 and dump978. 
+	Position_valid      bool	// set when position report received. Unset after n seconds? (To-do)
+	Lat                 float32 // decimal degrees, north positive
+	Lng                 float32 // decimal degrees, east positive
+	Alt                 int32 // Pressure altitude, feet
+	GnssDiffFromBaroAlt int32 // GNSS altitude above WGS84 datum. Reported in TC 20-22 messages
+	AltIsGNSS           bool  // Pressure alt = 0; GNSS alt = 1
+	NIC                 int   // Navigation Integrity Category.
+	NACp                int   // Navigation Accuracy Category for Position.
+	Track               uint16 // degrees true
+	Speed               uint16 // knots
+	Speed_valid         bool  // set when speed report received.
+	Vvel                int16  // feet per minute
+	Timestamp        time.Time // timestamp of traffic message, UTC
 
 	// Parameters starting at 'Age' are calculated after message receipt.
 	// Mode S transmits position and track in separate messages, and altitude can also be
 	// received from interrogations.
-	Age                  float64   // seconds ago traffic last seen
-	Last_seen            time.Time // time of last position update, relative to Stratux startup. Used for timing out expired data.
-	Last_alt             time.Time // time of last altitude update, relative to Stratux startup
-	Last_speed           time.Time // time of last velocity / track update, relative to Stratux startup
-	Last_source          uint8     // last SDR on which this target was observed
-	ExtrapolatedPosition bool      // TO-DO: True if Stratux is "coasting" the target from last known position.
-	Bearing              float64   // TO-DO: Bearing in degrees true to traffic from ownship
-	Distance             float64   // TO-DO: Distance to traffic from ownship
+	Age              float64   // seconds ago traffic last seen
+	Last_seen        time.Time // time of last position update, relative to Stratux startup. Used for timing out expired data.
+	Last_alt         time.Time // time of last altitude update, relative to Stratux startup
+	Last_GnssDiff    time.Time // time of last GnssDiffFromBaroAlt update, relative to Stratux startup
+	Last_GnssDiffAlt int32     // altitude at last GnssDiffFromBaroAlt update
+	Last_speed       time.Time // time of last velocity / track update, relative to Stratux startup
+	Last_source      uint8     // last SDR on which this target was observed
+	ExtrapolatedPosition bool // TO-DO: True if Stratux is "coasting" the target from last known position.
+	Bearing	float64  // TO-DO: Bearing in degrees true to traffic from ownship
+	Distance float64 // TO-DO: Distance to traffic from ownship
 }
 
 type dump1090Data struct {
@@ -116,7 +118,7 @@ type dump1090Data struct {
 	SBS_MsgType         int // type of SBS message (used in "old" 1090 parsing)
 	SignalLevel         int // 0-255
 	Tail                *string
-	Squawk              *int // 12-bit squawk code in octal format
+	Squawk              *int      // 12-bit squawk code in octal format
 	Emitter_category    *int
 	OnGround            *bool
 	Lat                 *float32
@@ -124,13 +126,13 @@ type dump1090Data struct {
 	Position_valid      bool
 	NACp                *int
 	Alt                 *int
-	AltIsGNSS           bool   //
+	AltIsGNSS           bool // 
 	GnssDiffFromBaroAlt *int16 // GNSS height above baro altitude in feet; valid range is -3125 to 3125. +/- 3138 indicates larger difference.
 	Vvel                *int16
 	Speed_valid         bool
 	Speed               *uint16
 	Track               *uint16
-	Timestamp           time.Time // time traffic last seen, UTC
+	Timestamp        time.Time // time traffic last seen, UTC
 }
 
 var traffic map[uint32]TrafficInfo
@@ -139,7 +141,7 @@ var seenTraffic map[uint32]bool // Historical list of all ICAO addresses seen.
 
 func cleanupOldEntries() {
 	for icao_addr, ti := range traffic {
-		if stratuxClock.Since(ti.Last_seen) > 120*time.Second { // keep it in the database for up to 120 seconds, so we don't lose tail number, etc...
+		if stratuxClock.Since(ti.Last_seen) > 60*time.Second { // keep it in the database for up to 60 seconds, so we don't lose tail number, etc...
 			delete(traffic, icao_addr)
 		}
 	}
@@ -150,19 +152,22 @@ func sendTrafficUpdates() {
 	defer trafficMutex.Unlock()
 	cleanupOldEntries()
 	var msg []byte
-	log.Printf("List of all aircraft being tracked:\n")
-	log.Printf("===================================\n")
+	if ((stratuxClock.Time.Second() % 10) == 0) {
+		log.Printf("List of all aircraft being tracked:\n")
+		log.Printf("==================================================================\n")
+	}
 	for icao, ti := range traffic { // TO-DO: Limit number of aircraft in traffic message. ForeFlight 7.5 chokes at ~1000-2000 messages depending on iDevice RAM. Practical limit likely around ~500 aircraft without filtering.
 
-		// DEBUG: Print the list of all tracked targets to the log each second
-		s_out, err := json.Marshal(ti)
-		if err != nil {
-			log.Printf("Error generating output: %s\n", err.Error())
-		} else {
-			log.Printf("%X => %s\n", ti.Icao_addr, string(s_out))
+		// DEBUG: Print the list of all tracked targets (with data) to the log every ten seconds
+		if ((stratuxClock.Time.Second() % 10) == 0) {
+			s_out, err := json.Marshal(ti)
+			if err != nil {
+				log.Printf("Error generating output: %s\n", err.Error())
+			} else {
+				log.Printf("%X => %s\n", ti.Icao_addr, string(s_out))
+			}
+			// end of debug block
 		}
-		// end of debug block
-
 		ti.Age = stratuxClock.Since(ti.Last_seen).Seconds()
 		traffic[icao] = ti
 		//log.Printf("Traffic age of %X is %f seconds\n",icao,ti.Age)
@@ -236,7 +241,7 @@ func makeTrafficReportMsg(ti TrafficInfo) []byte {
 	}
 	msg[11] = byte((alt & 0xFF0) >> 4) // Altitude.
 	msg[12] = byte((alt & 0x00F) << 4)
-
+	
 	// "m" field. Lower four bits define indicator bits:
 	// - - 0 0   "tt" (msg[17]) is not valid
 	// - - 0 1   "tt" is true track
@@ -246,22 +251,22 @@ func makeTrafficReportMsg(ti TrafficInfo) []byte {
 	// - 1 - -   Report is extrapolated
 	// 0 - - -   On ground
 	// 1 - - -   Airborne
-
+	
 	// Define tt type / validity
 	if ti.Speed_valid {
-		msg[12] = msg[12] | 0x01 // assume true track
+		msg[12] = msg[12] | 0x01  // assume true track
 	}
-
+	
 	if ti.ExtrapolatedPosition {
 		msg[12] = msg[12] | 0x04
 	}
-
+	
 	if !ti.OnGround {
 		msg[12] = msg[12] | 0x08 // Airborne.
 	}
 
 	// Position containment / navigational accuracy
-	msg[13] = ((byte(ti.NIC) << 4) & 0xF0) | (byte(ti.NACp) & 0x0F)
+	msg[13] = ((byte(ti.NIC) << 4) & 0xF0) | ((byte(ti.NACp) & 0x0F))
 
 	// Horizontal velocity (speed).
 
@@ -302,23 +307,23 @@ func parseDownlinkReport(s string, signalLevel int32) {
 	msg_type := (uint8(frame[0]) >> 3) & 0x1f
 	addr_type := uint8(frame[0]) & 0x07
 	icao_addr := (uint32(frame[1]) << 16) | (uint32(frame[2]) << 8) | uint32(frame[3])
-
+	
 	trafficMutex.Lock()
 	defer trafficMutex.Unlock()
-
+		
 	// Retrieve previous information on this ICAO code.
 	if val, ok := traffic[icao_addr]; ok { // if we've already seen it, copy it in to do updates as it may contain some useful information like "tail" from 1090ES.
 		ti = val
-		log.Printf("Existing target %X imported for UAT update\n", icao_addr)
+		//log.Printf("Existing target %X imported for UAT update\n", icao_addr)
 	} else {
-		log.Printf("New target %X created for UAT update\n", icao_addr)
+		//log.Printf("New target %X created for UAT update\n", icao_addr)
 		ti.Last_seen = stratuxClock.Time // need to initialize to current stratuxClock so it doesn't get cut before we have a chance to populate a position message
 		ti.Icao_addr = icao_addr
 		ti.ExtrapolatedPosition = false
 	}
-
+	
 	ti.Addr_type = addr_type
-
+	
 	// Parse tail number, if available.
 	if msg_type == 1 || msg_type == 3 { // Need "MS" portion of message.
 		base40_alphabet := string("0123456789ABCDEFGHIJKLMNOPQRTSUVWXYZ  ..")
@@ -346,7 +351,7 @@ func parseDownlinkReport(s string, signalLevel int32) {
 			ti.Tail = "u" + ti.Tail
 		}
 	}
-
+		
 	// Extract emitter category.
 	if msg_type == 1 || msg_type == 3 {
 		v := (uint16(frame[17]) << 8) | (uint16(frame[18]))
@@ -357,11 +362,11 @@ func parseDownlinkReport(s string, signalLevel int32) {
 	//	fmt.Printf("%d, %d, %06X\n", msg_type, ti.Addr_type, ti.Icao_addr)
 
 	ti.NIC = int(frame[11] & 0x0F)
-
-	if (msg_type == 1) || (msg_type == 3) { // Since NACp is passed with normal UATreports, no need to use our ES hack.
-		ti.NACp = int((frame[25] >> 4) & 0x0F)
+		
+	if ((msg_type == 1) || (msg_type == 3)) { // Since NACp is passed with normal UATreports, no need to use our ES hack.
+		ti.NACp = int((frame[25] >> 4) & 0x0F) 
 	}
-
+		
 	ti.SignalLevel = signalLevel
 
 	if ti.Addr_type == 0 {
@@ -372,11 +377,11 @@ func parseDownlinkReport(s string, signalLevel int32) {
 		ti.TargetType = TARGET_TYPE_ADSR
 	} else if ti.Addr_type == 2 {
 		ti.TargetType = TARGET_TYPE_TISB_S
-		if (ti.NIC >= 7) && (ti.Emitter_category > 0) { // If NIC is sufficiently and emitter type is transmitted, we'll assume it's ADS-R.
+		if ((ti.NIC >= 7) && (ti.Emitter_category > 0)) { // If NIC is sufficiently and emitter type is transmitted, we'll assume it's ADS-R.
 			ti.TargetType = TARGET_TYPE_ADSR
 		}
 	}
-
+	
 	raw_lat := (uint32(frame[4]) << 15) | (uint32(frame[5]) << 7) | (uint32(frame[6]) >> 1)
 	raw_lon := ((uint32(frame[6]) & 0x01) << 23) | (uint32(frame[7]) << 15) | (uint32(frame[8]) << 7) | (uint32(frame[9]) >> 1)
 
@@ -413,7 +418,7 @@ func parseDownlinkReport(s string, signalLevel int32) {
 	ti.Alt = alt
 	ti.AltIsGNSS = alt_geo
 	ti.Last_alt = stratuxClock.Time
-
+	
 	//OK.
 	//	fmt.Printf("%d, %t, %f, %f, %t, %d\n", nic, position_valid, lat, lng, alt_geo, alt)
 
@@ -497,7 +502,7 @@ func parseDownlinkReport(s string, signalLevel int32) {
 	if ti.Speed_valid {
 		ti.Last_speed = stratuxClock.Time
 	}
-
+	
 	//OK.
 	//	fmt.Printf("ns_vel %d, ew_vel %d, track %d, speed_valid %t, speed %d, vvel_geo %t, vvel %d\n", ns_vel, ew_vel, track, speed_valid, speed, vvel_geo, vvel)
 
@@ -516,7 +521,7 @@ func parseDownlinkReport(s string, signalLevel int32) {
 	//	fmt.Printf("tisb_site_id %d, utc_coupled %t\n", tisb_site_id, utc_coupled)
 
 	ti.Timestamp = time.Now()
-
+		
 	ti.Last_source = TRAFFIC_SOURCE_UAT
 
 	traffic[ti.Icao_addr] = ti
@@ -561,55 +566,55 @@ func esListen() {
 			thisMsg.TimeReceived = stratuxClock.Time
 			thisMsg.Data = []byte(buf)
 			MsgLog = append(MsgLog, thisMsg)
-
+						
 			icao := uint32(newTi.Icao_addr)
 			var ti TrafficInfo
-
+			
 			trafficMutex.Lock()
-
+		
 			// Retrieve previous information on this ICAO code.
 			if val, ok := traffic[icao]; ok { // if we've already seen it, copy it in to do updates
 				ti = val
-				log.Printf("Existing target %X imported for ES update\n", icao)
+				//log.Printf("Existing target %X imported for ES update\n", icao)
 			} else {
-				log.Printf("New target %X created for ES update\n", newTi.Icao_addr)
+				//log.Printf("New target %X created for ES update\n",newTi.Icao_addr)
 				ti.Last_seen = stratuxClock.Time // need to initialize to current stratuxClock so it doesn't get cut before we have a chance to populate a position message
 				ti.Icao_addr = icao
 				ti.ExtrapolatedPosition = false
 			}
-
+			
 			ti.SignalLevel = int32(newTi.SignalLevel)
-
+			
 			// generate human readable summary of message types for debug
 			// TO-DO: Use for ES message statistics?
 			/*
-				var s1 string
-				if newTi.DF == 17 {
-					s1 = "ADS-B"
-				}
-				if newTi.DF == 18 {
-					s1 = "ADS-R / TIS-B"
-				}
+			var s1 string
+			if newTi.DF == 17 {
+				s1 = "ADS-B"
+			}
+			if newTi.DF == 18 {
+				s1 = "ADS-R / TIS-B"
+			}
 
-				if newTi.DF == 4 || newTi.DF == 20 {
-					s1 = "Surveillance, Alt. Reply"
-				}
+			if newTi.DF == 4 || newTi.DF == 20 {
+				s1 = "Surveillance, Alt. Reply"
+			}
 
-				if newTi.DF == 5 || newTi.DF == 21 {
-					s1 = "Surveillance, Ident. Reply"
-				}
+			if newTi.DF == 5 || newTi.DF == 21 {
+				s1 = "Surveillance, Ident. Reply"
+			}
 
-				if newTi.DF == 11 {
-					s1 = "All-call Reply"
-				}
+			if newTi.DF == 11 {
+				s1 = "All-call Reply"
+			}
 
-				if newTi.DF == 0 {
-					s1 = "Short Air-Air Surv."
-				}
+			if newTi.DF == 0 {
+				s1 = "Short Air-Air Surv."
+			}
 
-				if newTi.DF == 16 {
-					s1 = "Long Air-Air Surv."
-				}
+			if newTi.DF == 16 {
+				s1 = "Long Air-Air Surv."
+			}
 			*/
 			//log.Printf("Mode S message from icao=%X, DF=%02d, CA=%02d, TC=%02d (%s)\n", ti.Icao_addr, newTi.DF, newTi.CA, newTi.TypeCode, s1)
 
@@ -617,16 +622,18 @@ func esListen() {
 			// and Mode S messages (DF=0, DF = 4, and DF = 20).
 
 			ti.AltIsGNSS = newTi.AltIsGNSS
-
+			
 			if newTi.Alt != nil {
 				ti.Alt = int32(*newTi.Alt)
 				ti.Last_alt = stratuxClock.Time
 			}
-
+			
 			if newTi.GnssDiffFromBaroAlt != nil {
 				ti.GnssDiffFromBaroAlt = int32(*newTi.GnssDiffFromBaroAlt) // we can estimate pressure altitude from GNSS height with this parameter!
+				ti.Last_GnssDiff = stratuxClock.Time
+				ti.Last_GnssDiffAlt = ti.Alt
 			}
-
+			
 			// Position updates are provided only by ES messages (DF=17 and DF=18; multiple TCs)
 			if newTi.Position_valid { // i.e. DF17 or DF18 message decoded successfully by dump1090
 				valid_position := true
@@ -636,14 +643,14 @@ func esListen() {
 					lat = float32(*newTi.Lat)
 				} else { // dump1090 send a valid message, but Stratux couldn't figure it out for some reason.
 					valid_position = false
-					log.Printf("Missing latitude in DF=17/18 airborne position message\n")
+					//log.Printf("Missing latitude in DF=17/18 airborne position message\n")
 				}
 
 				if newTi.Lng != nil {
 					lng = float32(*newTi.Lng)
 				} else { //
 					valid_position = false
-					log.Printf("Missing longitude in DF=17 airborne position message\n")
+					//log.Printf("Missing longitude in DF=17 airborne position message\n")
 				}
 
 				if valid_position {
@@ -663,20 +670,20 @@ func esListen() {
 					track = uint16(*newTi.Track)
 				} else { // dump1090 send a valid message, but Stratux couldn't figure it out for some reason.
 					valid_speed = false
-					log.Printf("Missing track in DF=17/18 TC19 airborne velocity message\n")
+					//log.Printf("Missing track in DF=17/18 TC19 airborne velocity message\n")
 				}
 
 				if newTi.Speed != nil {
 					speed = uint16(*newTi.Speed)
 				} else { //
 					valid_speed = false
-					log.Printf("Missing speed in DF=17/18 TC19 airborne velocity message\n")
+					//log.Printf("Missing speed in DF=17/18 TC19 airborne velocity message\n")
 				}
 
 				if newTi.Vvel != nil {
 					ti.Vvel = int16(*newTi.Vvel)
 				} else { // we'll still make the message without a valid vertical speed.
-					log.Printf("Missing vertical speed in DF=17/18 TC19 airborne velocity message\n")
+					//log.Printf("Missing vertical speed in DF=17/18 TC19 airborne velocity message\n")
 				}
 
 				if valid_speed {
@@ -684,8 +691,8 @@ func esListen() {
 					ti.Speed = speed
 					ti.Speed_valid = true
 					ti.Last_speed = stratuxClock.Time // only update "last seen" data on position updates
-				}
-			} else if ((newTi.DF == 17) || (newTi.DF == 18)) && (newTi.TypeCode == 19) { // invalid speed on velocity message only
+				} 
+			} else if (((newTi.DF == 17) || (newTi.DF == 18)) && (newTi.TypeCode == 19)) { // invalid speed on velocity message only
 				ti.Speed_valid = false
 			}
 
@@ -723,20 +730,20 @@ func esListen() {
 					nic = 11
 				}
 				ti.NIC = nic
-
-				if (ti.NACp < 7) && (ti.NACp < ti.NIC) {
+				
+				if ((ti.NACp < 7) && (ti.NACp < ti.NIC)) {
 					ti.NACp = ti.NIC // initialize to NIC, since NIC is sent with every position report, and not all emitters report NACp.
 				}
 			}
-
+	
 			if newTi.NACp != nil {
 				ti.NACp = *newTi.NACp
 			}
-
+									
 			if newTi.Emitter_category != nil {
-				ti.Emitter_category = uint8(*newTi.Emitter_category) // validate dump1090 on live traffic
-			}
-
+					ti.Emitter_category = uint8(*newTi.Emitter_category) // validate dump1090 on live traffic
+			} 
+			
 			// Set the target type. DF=18 messages are sent by ground station, so we look at CA
 			// (repurposed to Control Field in DF18) to determine if it's ADS-R or TIS-B.
 			if newTi.DF == 17 {
@@ -746,15 +753,15 @@ func esListen() {
 				if newTi.CA == 6 {
 					ti.TargetType = TARGET_TYPE_ADSR
 					ti.Addr_type = 2
-				} else if newTi.CA == 2 { // 2 = TIS-B with ICAO address, 5 = TIS-B without ICAO address
+				} else if (newTi.CA == 2) { // 2 = TIS-B with ICAO address, 5 = TIS-B without ICAO address
 					ti.TargetType = TARGET_TYPE_TISB
 					ti.Addr_type = 2
-				} else if newTi.CA == 5 {
+				} else if (newTi.CA == 5) {
 					ti.TargetType = TARGET_TYPE_TISB
 					ti.Addr_type = 3
 				}
 			}
-
+			
 			if newTi.OnGround != nil { // DF=11 messages don't report "on ground" status so we need to check for valid values.
 				ti.OnGround = bool(*newTi.OnGround)
 			}
@@ -773,14 +780,14 @@ func esListen() {
 			ti.Timestamp = newTi.Timestamp // only update "last seen" data on position updates
 			ti.Last_source = TRAFFIC_SOURCE_1090ES
 			/*
-				s_out, err := json.Marshal(ti)
-				if err != nil {
-					log.Printf("Error generating output: %s\n", err.Error())
-				} else {
-					log.Printf("%X (DF%d) => %s\n", ti.Icao_addr, newTi.DF, string(s_out))
-				}
+			s_out, err := json.Marshal(ti)
+			if err != nil {
+				log.Printf("Error generating output: %s\n", err.Error())
+			} else {
+				log.Printf("%X (DF%d) => %s\n", ti.Icao_addr, newTi.DF, string(s_out))
+			}
 			*/
-
+			
 			traffic[ti.Icao_addr] = ti // Update information on this ICAO code.
 			registerTrafficUpdate(ti)
 			seenTraffic[ti.Icao_addr] = true // Mark as seen.


### PR DESCRIPTION
Add Stratux-specific branch of MalcolmRobb/dump1090 and overhaul the traffic.go parsing routines.

**Dump1090 changes:**
- Add parsing of 1090ES TIS-B messages
- Add parsing of ADS-B / ADS-R / TIS-B NACp category from DF=17, TC=29/31 and DF=18, TC=19 messages
- Add parsing of GNSS altitude flag
- Add parsing of delta height between GNSS altitude and baro altitude
- New JSON-formatted output of fields used by traffic.go are sent on TCP port 30006. These include additions for NACp, signal strength, delta height, and GNSS height flag as noted in the [dump1090 README](https://github.com/AvSquirrel/dump1090#port-30006).

**Stratux changes:**
1090 ES parsing is completely overhauled to support the new dump1090 format. Additional ES parsing changes include:
- dump1090 raw signal strength is reported
- NIC is now calculated from DF17 position message type code
- NACp is reported when available (else, it is set to NIC, because not all emitters send this characteristic)
- Addr_type (UAT address qualifier) is set per the presence of DF=17 or DF=18 with the appropriate Control Field flag. This will allow GDL90-connected devices to identify whether targets are ADS-B, ADS-R, or TIS-B
-New TargetType flag will allow traffic source to be cleanly shown on UI traffic page (future commit)

978 UAT parsing improved to fix a couple of significant bugs:
- ti.OnGround initializes to 'false' when new ti is created, but is never explicitly set to false when vaild airborne messages are received. If a 978 target is ever seen on the ground, it will never be set to flight status.
- ew_vel and ns_vel changed from int16 to int32 to solve the zero airspeed issue noted in #277

Other 978 improvements include:
- NIC and NACp set from UAT message
- UAT signal strength is now passed to the traffic decoder and is tracked as part of each traffic target (similar to changes for 1090ES)

Refinements to GDL90 message packaging include:
- Track type set to "true track" rather than "true heading" (latter applies mainly to surface vehicles). 
- Add support for setting "Extrapolated position" flag for future traffic coasting algorithm
- Report actual NIC / NACp of targets, rather than hardcoded "1"

Other changes include:
- Traffic database is printed to stratux.log every ten seconds as a debug / troubleshooting aid. This frequency may be reduced or turned into a selectable debug option in future releases.
- Add tracking of delta height between GNSS altitude and baro altitude. This will eventually be used to feed this to a regression function that will estimate pressure altitude from GPS height.
- Added fields to support future target coasting.
- Added fields to support future target relative distance and bearing calculation

To-do items include:
- Traffic UI updates to show TIS-B / ADS-R status
- Target coasting
- Target relative distance and bearing
- Apply dump1090 improvements to [dump1090-mutability](https://github.com/mutability/dump1090), which is an actively-developed branch with numerous improvements that may improve 1090ES performance.


````
2016/02/24 04:05:30 List of all aircraft being tracked:
2016/02/24 04:05:30 ==================================================================
2016/02/24 04:05:30 AB4EEB => {"Icao_addr":11226859,"Tail":"","Emitter_category":0,"OnGround":false,"Addr_type":0,"TargetType":0,"SignalLevel":4,"Position_valid":false,"Lat":0,"Lng":0,"Alt":0,"GnssDiffFromBaroAlt":0,"AltIsGNSS":false,"NIC":0,"NACp":0,"Track":0,"Speed":0,"Speed_valid":false,"Vvel":0,"Timestamp":"2016-02-24T04:05:26.369Z","Age":3.3,"Last_seen":"0001-01-01T00:00:15.8Z","Last_alt":"0001-01-01T00:00:00Z","Last_GnssDiff":"0001-01-01T00:00:00Z","Last_GnssDiffAlt":0,"Last_speed":"0001-01-01T00:00:00Z","Last_source":1,"ExtrapolatedPosition":false,"Bearing":0,"Distance":0}
2016/02/24 04:05:30 A8D273 => {"Icao_addr":11063923,"Tail":"FDX1231","Emitter_category":0,"OnGround":false,"Addr_type":0,"TargetType":1,"SignalLevel":17,"Position_valid":true,"Lat":44.567,"Lng":-95.30189,"Alt":37000,"GnssDiffFromBaroAlt":-500,"AltIsGNSS":false,"NIC":8,"NACp":8,"Track":158,"Speed":469,"Speed_valid":true,"Vvel":0,"Timestamp":"2016-02-24T04:05:30.596Z","Age":1,"Last_seen":"0001-01-01T00:00:20.05Z","Last_alt":"0001-01-01T00:00:20.05Z","Last_GnssDiff":"0001-01-01T00:00:17.35Z","Last_GnssDiffAlt":37000,"Last_speed":"0001-01-01T00:00:17.35Z","Last_source":1,"ExtrapolatedPosition":false,"Bearing":0,"Distance":0}
2016/02/24 04:05:30 A7E5FD => {"Icao_addr":11003389,"Tail":"","Emitter_category":0,"OnGround":false,"Addr_type":0,"TargetType":0,"SignalLevel":12,"Position_valid":false,"Lat":0,"Lng":0,"Alt":37000,"GnssDiffFromBaroAlt":0,"AltIsGNSS":false,"NIC":0,"NACp":0,"Track":0,"Speed":0,"Speed_valid":false,"Vvel":0,"Timestamp":"2016-02-24T04:05:30.323Z","Age":15.4,"Last_seen":"0001-01-01T00:00:03.7Z","Last_alt":"0001-01-01T00:00:19.75Z","Last_GnssDiff":"0001-01-01T00:00:00Z","Last_GnssDiffAlt":0,"Last_speed":"0001-01-01T00:00:00Z","Last_source":1,"ExtrapolatedPosition":false,"Bearing":0,"Distance":0}
2016/02/24 04:05:30 A0678C => {"Icao_addr":10512268,"Tail":"1200","Emitter_category":1,"OnGround":true,"Addr_type":0,"TargetType":1,"SignalLevel":293,"Position_valid":true,"Lat":44.829132,"Lng":-93.456116,"Alt":975,"GnssDiffFromBaroAlt":0,"AltIsGNSS":false,"NIC":9,"NACp":10,"Track":99,"Speed":16,"Speed_valid":true,"Vvel":0,"Timestamp":"2016-02-24T04:05:28.705115282Z","Age":0.9,"Last_seen":"0001-01-01T00:00:18.2Z","Last_alt":"0001-01-01T00:00:18.2Z","Last_GnssDiff":"0001-01-01T00:00:00Z","Last_GnssDiffAlt":0,"Last_speed":"0001-01-01T00:00:18.2Z","Last_source":2,"ExtrapolatedPosition":false,"Bearing":0,"Distance":0}
2016/02/24 04:05:30 A40D8D => {"Icao_addr":10751373,"Tail":"","Emitter_category":0,"OnGround":false,"Addr_type":0,"TargetType":0,"SignalLevel":9,"Position_valid":false,"Lat":0,"Lng":0,"Alt":4050,"GnssDiffFromBaroAlt":0,"AltIsGNSS":false,"NIC":0,"NACp":0,"Track":0,"Speed":0,"Speed_valid":false,"Vvel":0,"Timestamp":"2016-02-24T04:05:30.146Z","Age":13.75,"Last_seen":"0001-01-01T00:00:05.35Z","Last_alt":"0001-01-01T00:00:19.6Z","Last_GnssDiff":"0001-01-01T00:00:00Z","Last_GnssDiffAlt":0,"Last_speed":"0001-01-01T00:00:00Z","Last_source":1,"ExtrapolatedPosition":false,"Bearing":0,"Distance":0}
2016/02/24 04:05:30 A48A83 => {"Icao_addr":10783363,"Tail":"","Emitter_category":0,"OnGround":false,"Addr_type":0,"TargetType":0,"SignalLevel":12,"Position_valid":false,"Lat":0,"Lng":0,"Alt":11425,"GnssDiffFromBaroAlt":0,"AltIsGNSS":false,"NIC":0,"NACp":0,"Track":0,"Speed":0,"Speed_valid":false,"Vvel":0,"Timestamp":"2016-02-24T04:05:30.647Z","Age":10.95,"Last_seen":"0001-01-01T00:00:08.15Z","Last_alt":"0001-01-01T00:00:19.95Z","Last_GnssDiff":"0001-01-01T00:00:00Z","Last_GnssDiffAlt":0,"Last_speed":"0001-01-01T00:00:00Z","Last_source":1,"ExtrapolatedPosition":false,"Bearing":0,"Distance":0}
2016/02/24 04:05:30 AB9A32 => {"Icao_addr":11246130,"Tail":"DAL1605","Emitter_category":0,"OnGround":false,"Addr_type":0,"TargetType":1,"SignalLevel":16,"Position_valid":true,"Lat":44.98366,"Lng":-93.81768,"Alt":15075,"GnssDiffFromBaroAlt":-500,"AltIsGNSS":false,"NIC":8,"NACp":8,"Track":284,"Speed":358,"Speed_valid":true,"Vvel":2944,"Timestamp":"2016-02-24T04:05:28.545Z","Age":1.1,"Last_seen":"0001-01-01T00:00:18Z","Last_alt":"0001-01-01T00:00:18Z","Last_GnssDiff":"0001-01-01T00:00:13.85Z","Last_GnssDiffAlt":14825,"Last_speed":"0001-01-01T00:00:13.85Z","Last_source":1,"ExtrapolatedPosition":false,"Bearing":0,"Distance":0}
2016/02/24 04:05:30 A35A92 => {"Icao_addr":10705554,"Tail":"","Emitter_category":0,"OnGround":false,"Addr_type":0,"TargetType":0,"SignalLevel":22,"Position_valid":false,"Lat":0,"Lng":0,"Alt":18825,"GnssDiffFromBaroAlt":0,"AltIsGNSS":false,"NIC":0,"NACp":0,"Track":0,"Speed":0,"Speed_valid":false,"Vvel":0,"Timestamp":"2016-02-24T04:05:30.576Z","Age":15.8,"Last_seen":"0001-01-01T00:00:03.3Z","Last_alt":"0001-01-01T00:00:18.55Z","Last_GnssDiff":"0001-01-01T00:00:00Z","Last_GnssDiffAlt":0,"Last_speed":"0001-01-01T00:00:00Z","Last_source":1,"ExtrapolatedPosition":false,"Bearing":0,"Distance":0}
2016/02/24 04:05:30 A54C42 => {"Icao_addr":10832962,"Tail":"","Emitter_category":0,"OnGround":false,"Addr_type":0,"TargetType":0,"SignalLevel":9,"Position_valid":false,"Lat":0,"Lng":0,"Alt":13325,"GnssDiffFromBaroAlt":0,"AltIsGNSS":false,"NIC":0,"NACp":0,"Track":0,"Speed":0,"Speed_valid":false,"Vvel":0,"Timestamp":"2016-02-24T04:05:28.877Z","Age":2.3,"Last_seen":"0001-01-01T00:00:16.8Z","Last_alt":"0001-01-01T00:00:18.3Z","Last_GnssDiff":"0001-01-01T00:00:00Z","Last_GnssDiffAlt":0,"Last_speed":"0001-01-01T00:00:00Z","Last_source":1,"ExtrapolatedPosition":false,"Bearing":0,"Distance":0}
2016/02/24 04:05:30 A448DB => {"Icao_addr":10766555,"Tail":"","Emitter_category":0,"OnGround":false,"Addr_type":0,"TargetType":0,"SignalLevel":7,"Position_valid":false,"Lat":0,"Lng":0,"Alt":0,"GnssDiffFromBaroAlt":0,"AltIsGNSS":false,"NIC":0,"NACp":0,"Track":0,"Speed":0,"Speed_valid":false,"Vvel":0,"Timestamp":"2016-02-24T04:05:28.367Z","Age":1.25,"Last_seen":"0001-01-01T00:00:17.85Z","Last_alt":"0001-01-01T00:00:00Z","Last_GnssDiff":"0001-01-01T00:00:00Z","Last_GnssDiffAlt":0,"Last_speed":"0001-01-01T00:00:00Z","Last_source":1,"ExtrapolatedPosition":false,"Bearing":0,"Distance":0}
````