### PR TITLE
 when a dongle fails then close its process, ES read stdout/stderr simplified, update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.vscode/
 dump978/extract_nexrad
 dump978/uat2esnt
 dump978/uat2json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 dump978/extract_nexrad
 dump978/uat2esnt
 dump978/uat2json

--- a/main/sdr.go
+++ b/main/sdr.go
@@ -445,12 +445,13 @@ func sdrWatcher() {
 			return
 		}
 
-		// set to true when a ReadSync call fails
+		// true when a ReadSync call fails
 		if shutdownUAT {
 			UATDev.shutdown()
 			UATDev = nil
 			shutdownUAT = false
 		}
+		// true when we get stderr output
 		if shutdownES {
 			ESDev.shutdown()
 			ESDev = nil

--- a/main/sdr.go
+++ b/main/sdr.go
@@ -75,8 +75,8 @@ func (e *ES) read() {
 				replayLog(scanStdout.Text(), MSGCLASS_DUMP1090)
 			}
 			if err := scanStdout.Err(); err != nil {
-        		log.Printf("scanStdout error: %s\n", err)
-    		}
+				log.Printf("scanStdout error: %s\n", err)
+			}
 
 			for scanStderr.Scan() {
 				replayLog(scanStderr.Text(), MSGCLASS_DUMP1090)
@@ -85,8 +85,8 @@ func (e *ES) read() {
 				}
 			}
 			if err := scanStderr.Err(); err != nil {
-        		log.Printf("scanStdout error: %s\n", err)
-    		}
+				log.Printf("scanStdout error: %s\n", err)
+			}
 
 			time.Sleep(1 * time.Second)
 		}

--- a/main/sdr.go
+++ b/main/sdr.go
@@ -449,7 +449,7 @@ func sdrWatcher() {
 		if shutdownUAT {
 			UATDev.shutdown()
 			UATDev = nil
-			shutdownUAT = true
+			shutdownUAT = false
 		}
 		if shutdownES {
 			ESDev.shutdown()

--- a/main/sdr.go
+++ b/main/sdr.go
@@ -416,13 +416,12 @@ func configDevices(count int, es_enabled, uat_enabled bool) {
 	}
 }
 
-// chicken and egg - to gracefully shut down a read method we
-// check a channel for a close flag, but now we want to handle
-// catastrophic dongle failures (when ReadSync returns an error
-// or we get stderr ouput) but we can't just bypass the channel
-// check and return directly from a goroutine because the close
-// channel call in the shutdown method will cause a runtime panic,
-// hence these...
+// to gracefully shut down a read method we check a channel for
+// a close flag, but now we want to handle catastrophic dongle
+// failures (when ReadSync returns an error or we get stderr
+// ouput) but we can't just bypass the channel check and return
+// directly from a goroutine because the close channel call in
+// the shutdown method will cause a runtime panic, hence these...
 var shutdownES bool
 var shutdownUAT bool
 

--- a/main/sdr.go
+++ b/main/sdr.go
@@ -418,8 +418,8 @@ func configDevices(count int, es_enabled, uat_enabled bool) {
 
 // chicken and egg - to gracefully shut down a read method we
 // check a channel for a close flag, but now we want to handle
-// catastrophic dongle failures (identified when ReadSync returns
-// an error) but we can't just bypass the channel check and
+// catastrophic dongle failures (when ReadSync returns or we get
+// stderr ouput) but we can't just bypass the channel check and
 // return directly from the goroutine because the close channel
 // call in shutdown will cause a runtime panic, hence these...
 var shutdownES bool

--- a/main/sdr.go
+++ b/main/sdr.go
@@ -64,7 +64,7 @@ func (e *ES) read() {
 			log.Println("ES read(): shutdown msg received, calling cmd.Process.Kill() ...")
 			err := cmd.Process.Kill()
 			if err != nil {
-				log.Println("\t couldn't kill dump1090: %s", err)
+				log.Printf("\t couldn't kill dump1090: %s\n", err)
 			} else {
 				cmd.Wait()
 				log.Println("\t kill successful...")

--- a/main/sdr.go
+++ b/main/sdr.go
@@ -418,10 +418,11 @@ func configDevices(count int, es_enabled, uat_enabled bool) {
 
 // chicken and egg - to gracefully shut down a read method we
 // check a channel for a close flag, but now we want to handle
-// catastrophic dongle failures (when ReadSync returns or we get
-// stderr ouput) but we can't just bypass the channel check and
-// return directly from the goroutine because the close channel
-// call in shutdown will cause a runtime panic, hence these...
+// catastrophic dongle failures (when ReadSync returns an error 
+// or we get stderr ouput) but we can't just bypass the channel 
+// check and return directly from a goroutine because the close 
+// channel call in the shutdown method will cause a runtime panic, 
+// hence these...
 var shutdownES bool
 var shutdownUAT bool
 

--- a/main/sdr.go
+++ b/main/sdr.go
@@ -418,10 +418,10 @@ func configDevices(count int, es_enabled, uat_enabled bool) {
 
 // chicken and egg - to gracefully shut down a read method we
 // check a channel for a close flag, but now we want to handle
-// catastrophic dongle failures (when ReadSync returns an error 
-// or we get stderr ouput) but we can't just bypass the channel 
-// check and return directly from a goroutine because the close 
-// channel call in the shutdown method will cause a runtime panic, 
+// catastrophic dongle failures (when ReadSync returns an error
+// or we get stderr ouput) but we can't just bypass the channel
+// check and return directly from a goroutine because the close
+// channel call in the shutdown method will cause a runtime panic,
 // hence these...
 var shutdownES bool
 var shutdownUAT bool

--- a/main/sdr.go
+++ b/main/sdr.go
@@ -85,7 +85,7 @@ func (e *ES) read() {
 				}
 			}
 			if err := scanStderr.Err(); err != nil {
-				log.Printf("scanStdout error: %s\n", err)
+				log.Printf("scanStderr error: %s\n", err)
 			}
 
 			time.Sleep(1 * time.Second)


### PR DESCRIPTION
When a dongle has failed catastrophically we assume ReadSync fails for UAT and we get stderr output for ES.