### PR TITLE
fix wmm parameter name

### DIFF
--- a/image/hostapd.conf
+++ b/image/hostapd.conf
@@ -2,6 +2,6 @@ interface=wlan0
 ssid=stratux
 hw_mode=g
 channel=1
-wme_enabled=1
+wmm_enabled=1
 ieee80211n=1
 ignore_broadcast_ssid=0


### PR DESCRIPTION
as per reading the default hostapd conf file, settings for ieee80211n=1 requires wmm_enabled to be set, not wme_enabled.

ieee80211n: Whether IEEE 802.11n (HT) is enabled
0 = disabled (default)
1 = enabled
Note: You will also need to enable WMM for full HT functionality.
Note: hw_mode=g (2.4 GHz) and hw_mode=a (5 GHz) is used to specify the band.
ieee80211n=1