### PR TITLE
image: add rpi0 and explicit edimax dongle check

### DIFF
--- a/image/stratux-wifi.sh
+++ b/image/stratux-wifi.sh
@@ -11,14 +11,13 @@
 
 DAEMON_CONF=/etc/hostapd/hostapd.conf
 DAEMON_SBIN=/usr/sbin/hostapd
+EW7811Un=$(lsusb | grep EW-7811Un)
 RPI_REV=`cat /proc/cpuinfo | grep 'Revision' | awk '{print $3}' | sed 's/^1000//'`
-if [ "$RPI_REV" = "a01041" ] || [ "$RPI_REV" = "a21041" ] ; then
- # This is a RPi2B.
+if [ "$RPI_REV" = "a01041" ] || [ "$RPI_REV" = "a21041" ]  || [ "$RPI_REV" = "900092" ] && [ "$EW7811Un" != '' ]; then
+ # This is a RPi2B or RPi0 with Edimax USB Wifi dongle.
  DAEMON_CONF=/etc/hostapd/hostapd-edimax.conf
  DAEMON_SBIN=/usr/sbin/hostapd-edimax
-fi
-if [ "$RPI_REV" = "a02082" ] || [ "$RPI_REV" = "a22082" ]; then
- # This is a RPi3B.
+else
  DAEMON_CONF=/etc/hostapd/hostapd.conf
 fi
 


### PR DESCRIPTION
Allows an RPi2 or RPi0 to use a non Edimax Wifi dongle provided it's natively supported.