### PR TITLE
circleci: allows PRs to correctly build themselves when the PR happens

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
   pre:
     - sudo apt-get update; sudo apt-get install libusb-1.0-0-dev; cd ~/; git clone https://github.com/jpoirier/librtlsdr; cd librtlsdr; mkdir build; cd build; cmake ../; make; sudo make install; sudo ldconfig; cd ~/; mkdir gopath; cd ~/; mkdir gopath; wget https://storage.googleapis.com/golang/go1.6.src.tar.gz; tar -zxvf go1.6.src.tar.gz; cd go/src; export GOROOT_BOOTSTRAP=/usr/local/go; ./make.bash; echo $PATH; echo $GOPATH; go version; env
   override:
-    - cd .. ; rm -rf stratux ; git clone --recursive https://github.com/cyoung/stratux ; cd stratux ; git fetch origin ; git checkout $CIRCLE_BRANCH ; make
+    - cd .. ; rm -rf stratux ; git clone --recursive https://github.com/cyoung/stratux ; cd stratux ; git config --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin/pr/*" ; git fetch origin ; BRANCH=`echo "$CIRCLE_BRANCH" | sed 's/pull\//pr\//g'` ; git checkout $BRANCH ; make
 
 test:
   override:


### PR DESCRIPTION
Currently when PRs hit circleci the actual PR branch that's submitted isn't being built due a PR branch naming conflict, circle tags PRs with pull/XXX whereas git has them listed as pr/XXX, this PR adjusts pull/XXX to pr/XXX.

I deleted the previous PR's branch during branch cleanup.