### PR TITLE
Add missing fields for multiple-row INSERT

### DIFF
--- a/main/datalog.go
+++ b/main/datalog.go
@@ -216,16 +216,17 @@ func bulkInsert(tbl string, db *sql.DB) (res sql.Result, err error) {
 
 	batchVals := insertBatchIfs[tbl]
 	for len(batchVals) > 0 {
-		i := int(0) // Maximum of 25 rows per INSERT statement.
+		i := int(0)
 		stmt := ""
 		vals := make([]interface{}, 0)
-		querySize := uint64(0) // Size of the query in bytes.
-		for len(batchVals) > 0 && i < 1000 && querySize < 750000 {
+		querySize := uint64(0)                                   // Size of the query in bytes.
+		for len(batchVals) > 0 && i < 30 && querySize < 750000 { // Maximum of 1000? columns for INSERT on default sqlite compile. trafficData is limiting function with 31 parameters.
 			if len(stmt) == 0 { // The first set will be covered by insertString.
 				stmt = insertString[tbl]
 				querySize += uint64(len(insertString[tbl]))
 			} else {
 				addStr := ", (" + strings.Join(strings.Split(strings.Repeat("?", len(batchVals[0])), ""), ",") + ")"
+				stmt += addStr
 				querySize += uint64(len(addStr))
 			}
 			for _, val := range batchVals[0] {
@@ -235,9 +236,10 @@ func bulkInsert(tbl string, db *sql.DB) (res sql.Result, err error) {
 			batchVals = batchVals[1:]
 			i++
 		}
-		//		log.Printf("inserting %d rows to %s. querySize=%d\n", i, tbl, querySize)
+		// log.Printf("inserting %d rows to %s. querySize=%d\n", i, tbl, querySize) // debug
 		res, err = db.Exec(stmt, vals...)
 		if err != nil {
+			log.Printf("sqlite insert error: '%s'\n", err.Error())
 			return
 		}
 	}
@@ -338,7 +340,7 @@ func dataLogWriter(db *sql.DB) {
 	dataLogWriteChan = make(chan DataLogRow, 10240)
 	// The write queue. As data comes in via dataLogChan, it is timestamped and stored.
 	//  When writeTicker comes up, the queue is emptied.
-	writeTicker := time.NewTicker(10 * time.Second)
+	writeTicker := time.NewTicker(500 * time.Millisecond)
 	rowsQueuedForWrite := make([]DataLogRow, 0)
 	for {
 		select {
@@ -362,6 +364,7 @@ func dataLogWriter(db *sql.DB) {
 			// Do the bulk inserts.
 			for tbl, _ := range tblsAffected {
 				bulkInsert(tbl, db)
+				//log.Printf("Doing bulk insert on %s\n",tbl)
 			}
 			// Close the transaction.
 			tx.Commit()


### PR DESCRIPTION
The SQLite `INSERT` in `bulkInsert()` was missing fields for all but the first row of each insert. This was what caused the log file to only contain one data point each ten seconds for the queueable tables.

To fix this, I add a  missing string concatenate to `stmt` to allow additional rows to be inserted.

I also had to limit the number of rows per insert to 30. This keeps the total number of columns under 1000, which seems to be the limit for this version of SQLite. To keep the queue clear, write ticker was reduced from 10 sec to 0.5 sec.