### PR TITLE
Add mutex to dataLogTimestamps[]

### DIFF
--- a/main/datalog.go
+++ b/main/datalog.go
@@ -47,6 +47,8 @@ var dataLogCurTimestamp int64 // Current timestamp bucket. This is an index on d
 */
 
 func checkTimestamp() bool {
+	logTimestampMutex.Lock()
+	defer logTimestampMutex.Unlock()
 	if stratuxClock.Since(dataLogTimestamps[dataLogCurTimestamp].StratuxClock_value) >= LOG_TIMESTAMP_RESOLUTION {
 		//FIXME: mutex.
 		var ts StratuxTimestamp
@@ -72,10 +74,8 @@ func checkTimestamp() bool {
 			}
 		}
 
-		logTimestampMutex.Lock()
 		dataLogCurTimestamp++
 		dataLogTimestamps[dataLogCurTimestamp] = ts
-		logTimestampMutex.Unlock()
 		return false
 	}
 	return true

--- a/main/datalog.go
+++ b/main/datalog.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -71,9 +72,10 @@ func checkTimestamp() bool {
 			}
 		}
 
+		logTimestampMutex.Lock()
 		dataLogCurTimestamp++
 		dataLogTimestamps[dataLogCurTimestamp] = ts
-
+		logTimestampMutex.Unlock()
 		return false
 	}
 	return true
@@ -219,7 +221,9 @@ func bulkInsert(tbl string, db *sql.DB) (res sql.Result, err error) {
 	maxRowBatch := int(999 / numColsPerRow) // SQLITE_MAX_VARIABLE_NUMBER = 999.
 	//	log.Printf("table %s. %d cols per row. max batch %d\n", tbl, numColsPerRow, maxRowBatch)
 	for len(batchVals) > 0 {
-		i := int(0) // Maximum of 25 rows per INSERT statement.
+		//timeInit := time.Now()
+		i := int(0) // Variable number of rows per INSERT statement.
+
 		stmt := ""
 		vals := make([]interface{}, 0)
 		querySize := uint64(0)                                            // Size of the query in bytes.
@@ -241,7 +245,10 @@ func bulkInsert(tbl string, db *sql.DB) (res sql.Result, err error) {
 		}
 		//		log.Printf("inserting %d rows to %s. querySize=%d\n", i, tbl, querySize)
 		res, err = db.Exec(stmt, vals...)
+		//timeBatch := time.Since(timeInit)                                                                                                                     // debug
+		//log.Printf("SQLite: bulkInserted %d rows to %s. Took %f msec to build and insert query. querySize=%d\n", i, tbl, 1000*timeBatch.Seconds(), querySize) // debug
 		if err != nil {
+			log.Printf("sqlite INSERT error: '%s'\n", err.Error())
 			return
 		}
 	}
@@ -333,6 +340,7 @@ type DataLogRow struct {
 	ts_num int64
 }
 
+var logTimestampMutex *sync.Mutex
 var dataLogChan chan DataLogRow
 var shutdownDataLog chan bool
 
@@ -390,7 +398,7 @@ func dataLog() {
 	dataLogChan = make(chan DataLogRow, 10240)
 	shutdownDataLog = make(chan bool)
 	dataLogTimestamps = make(map[int64]StratuxTimestamp, 0)
-
+	logTimestampMutex = &sync.Mutex{}
 	// Check if we need to create a new database.
 	createDatabase := false
 
@@ -458,8 +466,10 @@ func setDataLogTimeWithGPS(sit SituationData) {
 		ts.StratuxClock_value = stratuxClock.Time
 		ts.GPSClock_value = sit.GPSTime
 		ts.PreferredTime_value = sit.GPSTime
+		logTimestampMutex.Lock()
 		dataLogCurTimestamp++
 		dataLogTimestamps[dataLogCurTimestamp] = ts
+		logTimestampMutex.Unlock()
 	}
 }
 


### PR DESCRIPTION
**Problem:**
Intermittent out-of-bounds references to `dataLogTimestamps[dataLogCurTimestamp] = ts` cause crash after unpredictable amount of time. Cause seems to be simultaneous additions of new values to `dataLogTimestamps` in  `checkTimestamp()` and `setDataLogTimeWithGPS()`. 
```
unexpected fault address 0x30303030
fatal error: fault
[signal 0xb code=0x2 addr=0x30303030 pc=0xd7da8]

goroutine 45 [running]:
runtime.throw(0x4a0238, 0x5)
        /root/go/src/runtime/panic.go:527 +0x78 fp=0x10b31430 sp=0x10b31424
runtime.sigpanic()
        /root/go/src/runtime/sigpanic_unix.go:27 +0x280 fp=0x10b3145c sp=0x10b31430
runtime.evacuate(0x3f7550, 0x108c8260, 0x274)
        /root/go/src/runtime/hashmap.go:819 +0x1b8 fp=0x10b314c0 sp=0x10b31460
runtime.growWork(0x3f7550, 0x108c8260, 0x674)
        /root/go/src/runtime/hashmap.go:791 +0x6c fp=0x10b314d0 sp=0x10b314c0
runtime.mapassign1(0x3f7550, 0x108c8260, 0x67db90, 0x10b31574)
        /root/go/src/runtime/hashmap.go:433 +0x14c fp=0x10b31524 sp=0x10b314d0
main.setDataLogTimeWithGPS(0x1080f250, 0x4787d680, 0x42338aef, 0xc2bad45a, 0x1, 0x445228bd, 0xc2c9718f, 0xf0008, 0xa, 0x40f33333, ...)
        /root/stratux/main/datalog.go:441 +0x110 fp=0x10b315b0 sp=0x10b31524
main.processNMEALine(0x11c67d60, 0x42, 0x0)
        /root/stratux/main/ry835ai.go:678 +0x1c08 fp=0x10b31ebc sp=0x10b315b0
```

**Solution:**
Protect `dataLogCurTimestamp++` and `dataLogTimestamps[dataLogCurTimestamp]` by wrapping portions of `checkTimestamp()` and `setDataLogTimeWithGPS()` with mutex locks.