### PR TITLE
Fix geometric ownship alt overflow

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -319,11 +319,10 @@ func makeOwnshipGeometricAltitudeReport() bool {
 	}
 	msg := make([]byte, 5)
 	// See p.28.
-	msg[0] = 0x0B                 // Message type "Ownship Geo Alt".
-	alt := int16(mySituation.Alt) // GPS Altitude.
-	alt = alt / 5
-	msg[1] = byte(alt >> 8)     // Altitude.
-	msg[2] = byte(alt & 0x00FF) // Altitude.
+	msg[0] = 0x0B                     // Message type "Ownship Geo Alt".
+	alt := int16(mySituation.Alt / 5) // GPS Altitude, encoded to 16-bit int using 5-foot resolution
+	msg[1] = byte(alt >> 8)           // Altitude.
+	msg[2] = byte(alt & 0x00FF)       // Altitude.
 
 	//TODO: "Figure of Merit". 0x7FFF "Not available".
 	msg[3] = 0x00


### PR DESCRIPTION
Casting GPS altitude to int16 before encoding to 5-foot increments caused overflow (negative altitudes) above 32767 (0x7FFF) feet. Addresses #373.