### PR TITLE
Improve ownship track accuracy. Add disk usage to logs.

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -29,9 +29,9 @@ import (
 	"syscall"
 	"time"
 
-	humanize "github.com/dustin/go-humanize"
-
 	"../uatparse"
+	humanize "github.com/dustin/go-humanize"
+	"github.com/ricochet2200/go-disk-usage/du"
 )
 
 // http://www.faa.gov/nextgen/programs/adsb/wsa/media/GDL90_Public_ICD_RevA.PDF
@@ -71,6 +71,8 @@ const (
 	LON_LAT_RESOLUTION = float32(180.0 / 8388608.0)
 	TRACK_RESOLUTION   = float32(360.0 / 256.0)
 )
+
+var usage *du.DiskUsage
 
 var maxSignalStrength int
 
@@ -746,6 +748,9 @@ func updateStatus() {
 	globalStatus.Uptime = int64(stratuxClock.Milliseconds)
 	globalStatus.UptimeClock = stratuxClock.Time
 	globalStatus.Clock = time.Now()
+
+	usage = du.NewDiskUsage("/")
+	globalStatus.DiskBytesFree = usage.Free()
 }
 
 type WeatherMessage struct {
@@ -974,6 +979,7 @@ type status struct {
 	HardwareBuild                              string
 	Devices                                    uint32
 	Connected_Users                            uint
+	DiskBytesFree                              uint64
 	UAT_messages_last_minute                   uint
 	UAT_products_last_minute                   map[string]uint32
 	UAT_messages_max                           uint
@@ -1091,6 +1097,7 @@ func printStats() {
 		var memstats runtime.MemStats
 		runtime.ReadMemStats(&memstats)
 		log.Printf("stats [started: %s]\n", humanize.RelTime(time.Time{}, stratuxClock.Time, "ago", "from now"))
+		log.Printf(" - Disk bytes used = %s (%.1f %%), Disk bytes free = %s (%.1f %%) \n", humanize.Bytes(usage.Used()), 100*usage.Usage(), humanize.Bytes(usage.Free()), 100*(1-usage.Usage()))
 		log.Printf(" - CPUTemp=%.02f deg C, MemStats.Alloc=%s, MemStats.Sys=%s, totalNetworkMessagesSent=%s\n", globalStatus.CPUTemp, humanize.Bytes(uint64(memstats.Alloc)), humanize.Bytes(uint64(memstats.Sys)), humanize.Comma(int64(totalNetworkMessagesSent)))
 		log.Printf(" - UAT/min %s/%s [maxSS=%.02f%%], ES/min %s/%s\n, Total traffic targets tracked=%s", humanize.Comma(int64(globalStatus.UAT_messages_last_minute)), humanize.Comma(int64(globalStatus.UAT_messages_max)), float64(maxSignalStrength)/10.0, humanize.Comma(int64(globalStatus.ES_messages_last_minute)), humanize.Comma(int64(globalStatus.ES_messages_max)), humanize.Comma(int64(len(seenTraffic))))
 		log.Printf(" - Network data messages sent: %d total, %d nonqueueable.  Network data bytes sent: %d total, %d nonqueueable.\n", globalStatus.NetworkDataMessagesSent, globalStatus.NetworkDataMessagesSentNonqueueable, globalStatus.NetworkDataBytesSent, globalStatus.NetworkDataBytesSentNonqueueable)

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -290,11 +290,11 @@ func makeOwnshipReport() bool {
 	msg[16] = byte(verticalVelocity & 0xFF)
 
 	// Showing magnetic (corrected) on ForeFlight. Needs to be True Heading.
-	groundTrack := uint16(0)
+	groundTrack := float32(0)
 	if isGPSGroundTrackValid() {
 		groundTrack = mySituation.TrueCourse
 	}
-	trk := uint8(float32(groundTrack) / TRACK_RESOLUTION) // Resolution is ~1.4 degrees.
+	trk := uint8(groundTrack/TRACK_RESOLUTION - TRACK_RESOLUTION/2) // Resolution is ~1.4 degrees.
 
 	msg[17] = byte(trk)
 

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -29,9 +29,9 @@ import (
 	"syscall"
 	"time"
 
-	"../uatparse"
-	humanize "github.com/dustin/go-humanize"
 	"github.com/ricochet2200/go-disk-usage/du"
+	humanize "github.com/dustin/go-humanize"
+	"../uatparse"
 )
 
 // http://www.faa.gov/nextgen/programs/adsb/wsa/media/GDL90_Public_ICD_RevA.PDF
@@ -718,6 +718,10 @@ func cpuTempMonitor() {
 	}
 }
 
+
+
+
+
 func updateStatus() {
 	if mySituation.Quality == 2 {
 		globalStatus.GPS_solution = "DGPS (SBAS / WAAS)"
@@ -748,7 +752,7 @@ func updateStatus() {
 	globalStatus.Uptime = int64(stratuxClock.Milliseconds)
 	globalStatus.UptimeClock = stratuxClock.Time
 	globalStatus.Clock = time.Now()
-
+	
 	usage = du.NewDiskUsage("/")
 	globalStatus.DiskBytesFree = usage.Free()
 }
@@ -979,7 +983,7 @@ type status struct {
 	HardwareBuild                              string
 	Devices                                    uint32
 	Connected_Users                            uint
-	DiskBytesFree                              uint64
+	DiskBytesFree							   uint64
 	UAT_messages_last_minute                   uint
 	UAT_products_last_minute                   map[string]uint32
 	UAT_messages_max                           uint
@@ -1097,9 +1101,9 @@ func printStats() {
 		var memstats runtime.MemStats
 		runtime.ReadMemStats(&memstats)
 		log.Printf("stats [started: %s]\n", humanize.RelTime(time.Time{}, stratuxClock.Time, "ago", "from now"))
-		log.Printf(" - Disk bytes used = %s (%.1f %%), Disk bytes free = %s (%.1f %%) \n", humanize.Bytes(usage.Used()), 100*usage.Usage(), humanize.Bytes(usage.Free()), 100*(1-usage.Usage()))
+		log.Printf(" - Disk bytes used = %s (%.1f %%), Disk bytes free = %s (%.1f %%) \n",humanize.Bytes(usage.Used()), 100*usage.Usage(), humanize.Bytes(usage.Free()), 100*(1-usage.Usage()))
 		log.Printf(" - CPUTemp=%.02f deg C, MemStats.Alloc=%s, MemStats.Sys=%s, totalNetworkMessagesSent=%s\n", globalStatus.CPUTemp, humanize.Bytes(uint64(memstats.Alloc)), humanize.Bytes(uint64(memstats.Sys)), humanize.Comma(int64(totalNetworkMessagesSent)))
-		log.Printf(" - UAT/min %s/%s [maxSS=%.02f%%], ES/min %s/%s\n, Total traffic targets tracked=%s", humanize.Comma(int64(globalStatus.UAT_messages_last_minute)), humanize.Comma(int64(globalStatus.UAT_messages_max)), float64(maxSignalStrength)/10.0, humanize.Comma(int64(globalStatus.ES_messages_last_minute)), humanize.Comma(int64(globalStatus.ES_messages_max)), humanize.Comma(int64(len(seenTraffic))))
+		log.Printf(" - UAT/min %s/%s [maxSS=%.02f%%], ES/min %s/%s, Total traffic targets tracked=%s", humanize.Comma(int64(globalStatus.UAT_messages_last_minute)), humanize.Comma(int64(globalStatus.UAT_messages_max)), float64(maxSignalStrength)/10.0, humanize.Comma(int64(globalStatus.ES_messages_last_minute)), humanize.Comma(int64(globalStatus.ES_messages_max)), humanize.Comma(int64(len(seenTraffic))))
 		log.Printf(" - Network data messages sent: %d total, %d nonqueueable.  Network data bytes sent: %d total, %d nonqueueable.\n", globalStatus.NetworkDataMessagesSent, globalStatus.NetworkDataMessagesSentNonqueueable, globalStatus.NetworkDataBytesSent, globalStatus.NetworkDataBytesSentNonqueueable)
 		if globalSettings.GPS_Enabled {
 			log.Printf(" - Last GPS fix: %s, GPS solution type: %d using %d satellites (%d/%d seen/tracked), NACp: %d, est accuracy %.02f m\n", stratuxClock.HumanizeTime(mySituation.LastFixLocalTime), mySituation.Quality, mySituation.Satellites, mySituation.SatellitesSeen, mySituation.SatellitesTracked, mySituation.NACp, mySituation.Accuracy)
@@ -1259,7 +1263,7 @@ func main() {
 		globalSettings.ReplayLog = true
 	}
 
-	//FIXME: Only do this if data logging is enabled.
+	    //FIXME: Only do this if data logging is enabled.
 	initDataLog()
 
 	initRY835AI()
@@ -1277,7 +1281,7 @@ func main() {
 
 	// Monitor RPi CPU temp.
 	go cpuTempMonitor()
-
+	
 	reader := bufio.NewReader(os.Stdin)
 
 	if *replayFlag == true {


### PR DESCRIPTION
- `mySituation.TrueCourse` is stored as an int, even though GPS provides Course Over Ground with two places of precision beyond the decimal. This changes `TrueCourse` to a `float32` to preserve this information, and therefore eliminate up to 1 degree of track error.
- Reduce the quantization error when converting `mySituation.TrueCourse` to GDL90 8-bit `tt` track. This will provide more accurate track data in the GDL90 messages. (#368)
- Add periodic polling of free / used disk space to `globalStatus` and stratux.log.
- Remove extraneous newline in `printStats()`