### PR TITLE
Better edimax dongle handling in a RPi2 or RPi3

### DIFF
--- a/image/stratux-wifi.sh
+++ b/image/stratux-wifi.sh
@@ -19,7 +19,7 @@ echo 'LSUSB Returned: '$EW7811Un
 RPI_REV=`cat /proc/cpuinfo | grep 'Revision' | awk '{print $3}' | sed 's/^1000//'`
 
 if [ "$RPI_REV" = "a01041" ] || [ "$RPI_REV" = "a21041" ]  || [ "$RPI_REV" = "900092" ]   || [ "$RPI_REV" = "a02082" ]    || [ "$RPI_REV" = "a22082" ]; then
-# If this is a PRPi2/3 [ "$wlan0mac" = '74:da:38' ]
+# If this is a PRPi2/3 
   if [ "$EW7811Un" != '' ] && [[ ${edimaxMac[*]} =~ "$wlan0mac" ]]; then
    # If there is an Edimax Nano at wlan0
    DAEMON_CONF=/etc/hostapd/hostapd-edimax.conf

--- a/image/stratux-wifi.sh
+++ b/image/stratux-wifi.sh
@@ -5,20 +5,26 @@
 /usr/bin/killall -9 hostapd hostapd-edimax
 /usr/sbin/service isc-dhcp-server stop
 
+edimaxMac=(00:1f:1f 80:1f:02 74:da:38)
 
 #  Detect RPi2 or 3 with edimax dongle at wlan0
 #  Per http://elinux.org/RPi_HardwareHistory
 
 DAEMON_CONF=/etc/hostapd/hostapd.conf
 DAEMON_SBIN=/usr/sbin/hostapd
-EW7811Un=$(head -c 8 /sys/class/net/wlan0/address)
-#echo 'WLAN0 MAC '$EW7811Un
+EW7811Un=$(lsusb | grep EW-7811Un)
+wlan0mac=$(head -c 8 /sys/class/net/wlan0/address)
+echo 'WLAN0 MAC: '$wlan0mac
+echo 'LSUSB Returned: '$EW7811Un
 RPI_REV=`cat /proc/cpuinfo | grep 'Revision' | awk '{print $3}' | sed 's/^1000//'`
 
-if [ "$RPI_REV" = "a01041" ] || [ "$RPI_REV" = "a21041" ]  || [ "$RPI_REV" = "900092" ]   || [ "$RPI_REV" = "a02082" ]    || [ "$RPI_REV" = "a22082" ]  &&   [ "$EW7811Un" = '74:da:38' ]; then
- # This is a RPi2B or RPi3B with Edimax Nano at wlan0
- DAEMON_CONF=/etc/hostapd/hostapd-edimax.conf
- DAEMON_SBIN=/usr/sbin/hostapd-edimax
+if [ "$RPI_REV" = "a01041" ] || [ "$RPI_REV" = "a21041" ]  || [ "$RPI_REV" = "900092" ]   || [ "$RPI_REV" = "a02082" ]    || [ "$RPI_REV" = "a22082" ]; then
+# If this is a PRPi2/3 [ "$wlan0mac" = '74:da:38' ]
+  if [ "$EW7811Un" != '' ] && [[ ${edimaxMac[*]} =~ "$wlan0mac" ]]; then
+   # If there is an Edimax Nano at wlan0
+   DAEMON_CONF=/etc/hostapd/hostapd-edimax.conf
+   DAEMON_SBIN=/usr/sbin/hostapd-edimax
+ fi
 fi
 
 #Example:

--- a/image/stratux-wifi.sh
+++ b/image/stratux-wifi.sh
@@ -11,18 +11,25 @@
 
 DAEMON_CONF=/etc/hostapd/hostapd.conf
 DAEMON_SBIN=/usr/sbin/hostapd
-EW7811Un=$(lsusb | grep EW-7811Un)
+EW7811Un=$(head -c 8 /sys/class/net/wlan0/address)
+#echo 'WLAN0 MAC '$EW7811Un
 RPI_REV=`cat /proc/cpuinfo | grep 'Revision' | awk '{print $3}' | sed 's/^1000//'`
-if [ "$RPI_REV" = "a01041" ] || [ "$RPI_REV" = "a21041" ]  || [ "$RPI_REV" = "900092" ] && [ "$EW7811Un" != '' ]; then
- # This is a RPi2B or RPi0 with Edimax USB Wifi dongle.
+
+if [ "$RPI_REV" = "a01041" ] || [ "$RPI_REV" = "a21041" ]  || [ "$RPI_REV" = "900092" ]   || [ "$RPI_REV" = "a02082" ]    || [ "$RPI_REV" = "a22082" ]  &&   [ "$EW7811Un" = '74:da:38' ]; then
+ # This is a RPi2B.
  DAEMON_CONF=/etc/hostapd/hostapd-edimax.conf
  DAEMON_SBIN=/usr/sbin/hostapd-edimax
-else
- DAEMON_CONF=/etc/hostapd/hostapd.conf
 fi
+#if [ "$RPI_REV" = "a02082" ] || [ "$RPI_REV" = "a22082" ]; then
+ # This is a RPi3B.
+# DAEMON_CONF=/etc/hostapd/hostapd.conf
+#fi
 
-
+#Example:
+#/usr/sbin/hostapd-edimax -B /etc/hostapd/hostapd-edimax.conf
 ${DAEMON_SBIN} -B ${DAEMON_CONF}
+
+
 
 sleep 5
 

--- a/image/stratux-wifi.sh
+++ b/image/stratux-wifi.sh
@@ -6,7 +6,7 @@
 /usr/sbin/service isc-dhcp-server stop
 
 
-# Detect RPi version.
+#  Detect RPi2 or 3 with edimax dongle at wlan0
 #  Per http://elinux.org/RPi_HardwareHistory
 
 DAEMON_CONF=/etc/hostapd/hostapd.conf
@@ -16,20 +16,14 @@ EW7811Un=$(head -c 8 /sys/class/net/wlan0/address)
 RPI_REV=`cat /proc/cpuinfo | grep 'Revision' | awk '{print $3}' | sed 's/^1000//'`
 
 if [ "$RPI_REV" = "a01041" ] || [ "$RPI_REV" = "a21041" ]  || [ "$RPI_REV" = "900092" ]   || [ "$RPI_REV" = "a02082" ]    || [ "$RPI_REV" = "a22082" ]  &&   [ "$EW7811Un" = '74:da:38' ]; then
- # This is a RPi2B.
+ # This is a RPi2B or RPi3B with Edimax Nano at wlan0
  DAEMON_CONF=/etc/hostapd/hostapd-edimax.conf
  DAEMON_SBIN=/usr/sbin/hostapd-edimax
 fi
-#if [ "$RPI_REV" = "a02082" ] || [ "$RPI_REV" = "a22082" ]; then
- # This is a RPi3B.
-# DAEMON_CONF=/etc/hostapd/hostapd.conf
-#fi
 
 #Example:
 #/usr/sbin/hostapd-edimax -B /etc/hostapd/hostapd-edimax.conf
 ${DAEMON_SBIN} -B ${DAEMON_CONF}
-
-
 
 sleep 5
 


### PR DESCRIPTION
Since I develop on my Stratux using a second wifi dongle I found that if you plug in an additional wifi dongle into the RPi3 then that dongle will/might be seen as wlan0. If this dongle is an edimax wifi dongle and it is detected as wlan0 then the current stratux-wifi.sh will not be able to start the hostapd service.

This script will now ask the system to give the MAC address of the device at wlan0 and if the system is a RPi2 or RPi3.

If the system is a RPi2/3 and there is an edimax at wlan0 we will now start the hostapd-edimax driver with the hostapd-edimax.conf

This will also solve the issue of a RPi3 user having the on-board wifi stop working and the edimax nano to be used in its place.

Note:

As of right now there are 3 MAC blocks used by Edimax. I have 3 Edimax Nano's and all of them use the "74:da:38" Mac Block so I am not checking for the other 2 MAC blocks at this time. This could be changed in the future. 

http://macaddress.webwat.ch/vendor/Edimax_Technology_Co._Ltd. (add the period back to the end of this link)

I am only guessing that all the Edimax Nano's are in the 74:da:38 range and the 2 others are other devices.