### PR TITLE
GPS backend improvements

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -721,7 +721,7 @@ func cpuTempMonitor() {
 
 func updateStatus() {
 	if mySituation.Quality == 2 {
-		globalStatus.GPS_solution = "DGPS (SBAS / WAAS)"
+		globalStatus.GPS_solution = "GPS + SBAS (WAAS / EGNOS)"
 	} else if mySituation.Quality == 1 {
 		globalStatus.GPS_solution = "3D GPS"
 	} else if mySituation.Quality == 6 {

--- a/main/ry835ai.go
+++ b/main/ry835ai.go
@@ -1173,7 +1173,7 @@ If false, 'Quality` is set to 0 ("No fix"), as is the number of satellites in so
 
 func isGPSValid() bool {
 	isValid := false
-	if (stratuxClock.Since(mySituation.LastFixLocalTime) < 15*time.Second) && globalStatus.GPS_connected {
+	if (stratuxClock.Since(mySituation.LastFixLocalTime) < 15*time.Second) && globalStatus.GPS_connected && mySituation.Quality > 0 {
 		isValid = true
 	} else {
 		mySituation.Quality = 0


### PR DESCRIPTION
A few incremental improvements to GPS subsystem:
- Prioritize `/dev/ttyACM0` over `/dev/ttyUSB0` at startup. This will allow the simultaneous use of u-blox receivers over their native USB connection, while having a USB-to-serial bridges installed.
- 'isGPSValid()' now checks for a connected GPS device, and that the "quality" byte is greater than zero. This should prevent invalid positions (e.g. off the coast of Equatorial Guinea, 0°N / 0°W) from being used for traffic distance calculations at startup.
- Changed UI description for `quality==2` solution from "DGPS (SBAS / WAAS)" to "GPS + SBAS (WAAS / EGNOS)". While satellite-based augmentation is a differential method, "DGPS" more commonly refers to terrestrial differential corrections. The new description is more accurate for 99.9% of Stratux use cases. (The [EGNOS](https://en.wikipedia.org/wiki/European_Geostationary_Navigation_Overlay_Service) label is being added as a tip-of-the-hat to European Stratux users. It is Europe's SBAS, and serves the same role as WAAS in North America.)