### PR TITLE
Graceful shutdown of SQLite logs

### DIFF
--- a/main/datalog.go
+++ b/main/datalog.go
@@ -446,7 +446,7 @@ func dataLog() {
 	defer func() {
 		db.Close()
 		dataLogStarted = false
-		close(dataLogChan)
+		//close(dataLogChan)
 		log.Printf("datalog.go: dataLog() has closed DB in %s\n", dataLogFile)
 	}()
 
@@ -571,10 +571,8 @@ func initDataLog() {
 	//log.Printf("dataLogStarted = %t. dataLogReadyToWrite = %t\n", dataLogStarted, dataLogReadyToWrite) //REMOVE -- DEBUG
 	insertString = make(map[string]string)
 	insertBatchIfs = make(map[string][][]interface{})
-	if globalSettings.ReplayLog {
-		go dataLog()
-	}
 	go dataLogWatchdog()
+
 	//log.Printf("datalog.go: initDataLog() complete.\n") //REMOVE -- DEBUG
 }
 

--- a/main/datalog.go
+++ b/main/datalog.go
@@ -46,7 +46,6 @@ type StratuxStartup struct {
 var dataLogStarted bool
 var dataLogReadyToWrite bool
 
-//var dataLogInShutdown  bool
 var stratuxStartupID int64
 var dataLogTimestamps []StratuxTimestamp
 var dataLogCurTimestamp int64 // Current timestamp bucket. This is an index on dataLogTimestamps which is not necessarily the db id.
@@ -369,7 +368,6 @@ func dataLogWriter(db *sql.DB) {
 		select {
 		case r := <-dataLogWriteChan:
 			// Accept timestamped row.
-			//log.Printf("Accepting timestamped row from dataLogWriteChan\n")
 			rowsQueuedForWrite = append(rowsQueuedForWrite, r)
 		case <-writeTicker.C:
 			//			for i := 0; i < 1000; i++ {
@@ -411,7 +409,6 @@ func dataLogWriter(db *sql.DB) {
 		case <-shutdownDataLogWriter: // Received a message on the channel to initiate a graceful shutdown, and to command dataLog() to shut down
 			log.Printf("datalog.go: dataLogWriter() received shutdown message with rowsQueuedForWrite = %d\n", len(rowsQueuedForWrite))
 			shutdownDataLog <- true
-			defer close(shutdownDataLog)
 			return
 		}
 	}
@@ -499,6 +496,7 @@ func dataLog() {
 		}
 	}
 	log.Printf("datalog.go: dataLog() shutting down\n")
+	close(shutdownDataLog)
 }
 
 /*

--- a/main/datalog.go
+++ b/main/datalog.go
@@ -502,11 +502,15 @@ func logSituation() {
 }
 
 func logStatus() {
-	dataLogChan <- DataLogRow{tbl: "status", data: globalStatus}
+	if globalSettings.ReplayLog {
+		dataLogChan <- DataLogRow{tbl: "status", data: globalStatus}
+	}
 }
 
 func logSettings() {
-	dataLogChan <- DataLogRow{tbl: "settings", data: globalSettings}
+	if globalSettings.ReplayLog {
+		dataLogChan <- DataLogRow{tbl: "settings", data: globalSettings}
+	}
 }
 
 func logTraffic(ti TrafficInfo) {

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -962,16 +962,17 @@ func getProductNameFromId(product_id int) string {
 }
 
 type settings struct {
-	UAT_Enabled    bool
-	ES_Enabled     bool
-	GPS_Enabled    bool
-	NetworkOutputs []networkConnection
-	AHRS_Enabled   bool
-	DEBUG          bool
-	ReplayLog      bool
-	PPM            int
-	OwnshipModeS   string
-	WatchList      string
+	UAT_Enabled          bool
+	ES_Enabled           bool
+	GPS_Enabled          bool
+	NetworkOutputs       []networkConnection
+	AHRS_Enabled         bool
+	DisplayTrafficSource bool
+	DEBUG                bool
+	ReplayLog            bool
+	PPM                  int
+	OwnshipModeS         string
+	WatchList            string
 }
 
 type status struct {
@@ -1021,6 +1022,7 @@ func defaultSettings() {
 	}
 	globalSettings.AHRS_Enabled = false
 	globalSettings.DEBUG = false
+	globalSettings.DisplayTrafficSource = false
 	globalSettings.ReplayLog = false //TODO: 'true' for debug builds.
 	globalSettings.OwnshipModeS = "F00000"
 }
@@ -1190,15 +1192,14 @@ var sigs = make(chan os.Signal, 1) // Signal catch channel (shutdown).
 func gracefulShutdown() {
 	// Shut down SDRs.
 	sdrKill()
-	//TODO: Any other graceful shutdown functions.
 
 	// Shut down data logging.
 	if dataLogStarted {
 		closeDataLog()
-		//log.Printf("Waiting for log file to close\n")
-		//time.Sleep(3*time.Second) // FIXME
 	}
-	// shutdownDataLog <- true
+
+	//TODO: Any other graceful shutdown functions.
+
 	os.Exit(1)
 }
 

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1191,8 +1191,14 @@ func gracefulShutdown() {
 	// Shut down SDRs.
 	sdrKill()
 	//TODO: Any other graceful shutdown functions.
+
 	// Shut down data logging.
-	shutdownDataLog <- true
+	if dataLogStarted {
+		closeDataLog()
+		//log.Printf("Waiting for log file to close\n")
+		//time.Sleep(3*time.Second) // FIXME
+	}
+	// shutdownDataLog <- true
 	os.Exit(1)
 }
 

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -205,6 +205,8 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 						globalSettings.AHRS_Enabled = val.(bool)
 					case "DEBUG":
 						globalSettings.DEBUG = val.(bool)
+					case "DisplayTrafficSource":
+						globalSettings.DisplayTrafficSource = val.(bool)
 					case "ReplayLog":
 						v := val.(bool)
 						if v != globalSettings.ReplayLog { // Don't mark the files unless there is a change.

--- a/main/traffic.go
+++ b/main/traffic.go
@@ -400,7 +400,7 @@ func parseDownlinkReport(s string, signalLevel int) {
 	}
 
 	// This is a hack to show the source of the traffic on moving maps.
-	if globalSettings.DEBUG {
+	if globalSettings.DisplayTrafficSource {
 		type_code := " "
 		switch ti.TargetType {
 		case TARGET_TYPE_ADSB:
@@ -839,7 +839,7 @@ func esListen() {
 
 			// This is a hack to show the source of the traffic on moving maps.
 
-			if globalSettings.DEBUG {
+			if globalSettings.DisplayTrafficSource {
 				type_code := " "
 				switch ti.TargetType {
 				case TARGET_TYPE_ADSB:

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -6,7 +6,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 
 	$scope.$parent.helppage = 'plates/settings-help.html';
 
-	var toggles = ['UAT_Enabled', 'ES_Enabled', 'GPS_Enabled', 'AHRS_Enabled', 'DEBUG', 'ReplayLog']; // DEBUG is 'DspTrafficSrc'
+	var toggles = ['UAT_Enabled', 'ES_Enabled', 'GPS_Enabled', 'AHRS_Enabled', 'DisplayTrafficSource', 'DEBUG', 'ReplayLog']; 
 	var settings = {};
 	for (i = 0; i < toggles.length; i++) {
 		settings[toggles[i]] = undefined;
@@ -21,7 +21,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		$scope.ES_Enabled = settings.ES_Enabled;
 		$scope.GPS_Enabled = settings.GPS_Enabled;
 		$scope.AHRS_Enabled = settings.AHRS_Enabled;
-		$scope.PowerSave = settings.PowerSave
+		$scope.DisplayTrafficSource = settings.DisplayTrafficSource;
 		$scope.DEBUG = settings.DEBUG;
 		$scope.ReplayLog = settings.ReplayLog;
 		$scope.PPM = settings.PPM;

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -37,13 +37,19 @@
 			<div class="panel-heading">Diagnostics</div>
 			<div class="panel-body">
 				<div class="form-group">
-					<label class="control-label col-xs-7">Traffic Markings</label>
+					<label class="control-label col-xs-7">Show Traffic Source in Callsign</label>
+					<div class="col-xs-5">
+						<ui-switch ng-model='DisplayTrafficSource' settings-change></ui-switch>
+					</div>
+				</div>
+				<div class="form-group">
+					<label class="control-label col-xs-7">Verbose Message Log</label>
 					<div class="col-xs-5">
 						<ui-switch ng-model='DEBUG' settings-change></ui-switch>
 					</div>
 				</div>
 				<div class="form-group">
-					<label class="control-label col-xs-7">Record Logs</label>
+					<label class="control-label col-xs-7">Record Replay Logs</label>
 					<div class="col-xs-5">
 						<ui-switch ng-model='ReplayLog' settings-change></ui-switch>
 					</div>


### PR DESCRIPTION
- Add watchdog function and quitchannel controls for graceful shutdown and restart of sqlite logs. Log may now be started and stopped at any time.
- SQLite system now only runs when `globalSettings.ReplayLog == true`.
- SQLite database is safely and properly closed when log system is closed.
- globalStatus and globalSettings are only sent to log when `globalSettings.ReplayLog == true`
- Display of traffic source in callsign now split out from verbose 'DEBUG' setting