### PR TITLE
Udev updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ install:
 	cp -f gen_gdl90 /usr/bin/gen_gdl90
 	chmod 755 /usr/bin/gen_gdl90
 	cp init.d-stratux /etc/init.d/stratux
+	cp image/10-stratux.rules /etc/udev/rules.d/10-stratux.rules
 	chmod 755 /etc/init.d/stratux
 	ln -sf /etc/init.d/stratux /etc/rc2.d/S01stratux
 	ln -sf /etc/init.d/stratux /etc/rc6.d/K01stratux

--- a/image/10-stratux.rules
+++ b/image/10-stratux.rules
@@ -1,8 +1,18 @@
 # To be placed in /etc/udev/rules.d.
 #  Auto-detect common USB stratux peripherals.
 
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="1546", ATTRS{idProduct}=="01a7", SYMLINK+="vk172"
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="1546", ATTRS{idProduct}=="01a6", SYMLINK+="vk162"
+# u-blox devices. Known devices include
+#   ublox8: RY835AI, RY836AI
+#   ublox7: VK-172, RY725AI
+#   ublox6: VK-162
+
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1546", ATTRS{idProduct}=="01a8", SYMLINK+="ublox8"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1546", ATTRS{idProduct}=="01a7", SYMLINK+="ublox7"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1546", ATTRS{idProduct}=="01a6", SYMLINK+="ublox6"
+#SUBSYSTEMS=="usb", ATTRS{idVendor}=="1546", ATTRS{idProduct}=="01a7", SYMLINK+="vk172"
+#SUBSYSTEMS=="usb", ATTRS{idVendor}=="1546", ATTRS{idProduct}=="01a6", SYMLINK+="vk162"
+
+
 
 # pl2303 devices are indistinguishable using idVendor and idProduct.
 #  Currently the BU-353-S4 and the TU-S9 (serialout) use the pl2303.

--- a/main/ry835ai.go
+++ b/main/ry835ai.go
@@ -155,10 +155,12 @@ func initGPSSerial() bool {
 	baudrate := int(9600)
 	isSirfIV := bool(false)
 
-	if _, err := os.Stat("/dev/vk172"); err == nil { // u-blox 7.
-		device = "/dev/vk172"
-	} else if _, err := os.Stat("/dev/vk162"); err == nil { // u-blox 6.
-		device = "/dev/vk162"
+	if _, err := os.Stat("/dev/ublox8"); err == nil { // u-blox 8 (RY83xAI over USB).
+		device = "/dev/ublox8"
+	} else if _, err := os.Stat("/dev/ublox7"); err == nil { // u-blox 7 (VK-172, RY725AI over USB).
+		device = "/dev/ublox7"
+	} else if _, err := os.Stat("/dev/ublox6"); err == nil { // u-blox 6 (VK-162).
+		device = "/dev/ublox6"
 	} else if _, err := os.Stat("/dev/prolific0"); err == nil { // Assume it's a BU-353-S4 SIRF IV.
 		//TODO: Check a "serialout" flag and/or deal with multiple prolific devices.
 		isSirfIV = true


### PR DESCRIPTION
- Add udev rule for u-blox 8 devices (RY835, RY836AI) connected over USB
- Use generic descriptions for the u-blox 6 and 7 chipsets, rather than vendor-specific GPS models. 
- Add udev rules to Makefile. This will allow udev configuration to be updated through `git pull` / `make install`.