### PR TITLE
Additional UAT stability improvements (tower mutex, array bounds checks)

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -629,7 +629,7 @@ func updateMessageStats() {
 	m := len(MsgLog)
 	UAT_messages_last_minute := uint(0)
 	ES_messages_last_minute := uint(0)
-	products_last_minute := make(map[string]uint32)
+	//products_last_minute := make(map[string]uint32)
 
 	ADSBTowerMutex.Lock()
 
@@ -645,9 +645,9 @@ func updateMessageStats() {
 			t = append(t, MsgLog[i])
 			if MsgLog[i].MessageClass == MSGCLASS_UAT {
 				UAT_messages_last_minute++
-				for _, p := range MsgLog[i].Products {
-					products_last_minute[getProductNameFromId(int(p))]++
-				}
+				//for _, p := range MsgLog[i].Products {
+				//	products_last_minute[getProductNameFromId(int(p))]++
+				//}
 				if len(MsgLog[i].ADSBTowerID) > 0 { // Update tower stats.
 					tid := MsgLog[i].ADSBTowerID
 					twr := ADSBTowers[tid]
@@ -666,7 +666,7 @@ func updateMessageStats() {
 	MsgLog = t
 	globalStatus.UAT_messages_last_minute = UAT_messages_last_minute
 	globalStatus.ES_messages_last_minute = ES_messages_last_minute
-	globalStatus.UAT_products_last_minute = products_last_minute
+	//globalStatus.UAT_products_last_minute = products_last_minute
 
 	// Update "max messages/min" counters.
 	if globalStatus.UAT_messages_max < UAT_messages_last_minute {
@@ -987,14 +987,14 @@ type settings struct {
 }
 
 type status struct {
-	Version                                    string
-	Build                                      string
-	HardwareBuild                              string
-	Devices                                    uint32
-	Connected_Users                            uint
-	DiskBytesFree                              uint64
-	UAT_messages_last_minute                   uint
-	UAT_products_last_minute                   map[string]uint32
+	Version                  string
+	Build                    string
+	HardwareBuild            string
+	Devices                  uint32
+	Connected_Users          uint
+	DiskBytesFree            uint64
+	UAT_messages_last_minute uint
+	//UAT_products_last_minute                   map[string]uint32
 	UAT_messages_max                           uint
 	ES_messages_last_minute                    uint
 	ES_messages_max                            uint

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -151,6 +151,8 @@ func handleSituationRequest(w http.ResponseWriter, r *http.Request) {
 func handleTowersRequest(w http.ResponseWriter, r *http.Request) {
 	setNoCache(w)
 	setJSONHeaders(w)
+
+	ADSBTowerMutex.Lock()
 	towersJSON, err := json.Marshal(&ADSBTowers)
 	if err != nil {
 		log.Printf("Error sending tower JSON data: %s\n", err.Error())
@@ -158,6 +160,7 @@ func handleTowersRequest(w http.ResponseWriter, r *http.Request) {
 	// for testing purposes, we can return a fixed reply
 	// towersJSON = []byte(`{"(38.490880,-76.135554)":{"Lat":38.49087953567505,"Lng":-76.13555431365967,"Signal_strength_last_minute":100,"Signal_strength_max":67,"Messages_last_minute":1,"Messages_total":1059},"(38.978698,-76.309276)":{"Lat":38.97869825363159,"Lng":-76.30927562713623,"Signal_strength_last_minute":495,"Signal_strength_max":32,"Messages_last_minute":45,"Messages_total":83},"(39.179285,-76.668413)":{"Lat":39.17928457260132,"Lng":-76.66841268539429,"Signal_strength_last_minute":50,"Signal_strength_max":24,"Messages_last_minute":1,"Messages_total":16},"(39.666309,-74.315300)":{"Lat":39.66630935668945,"Lng":-74.31529998779297,"Signal_strength_last_minute":9884,"Signal_strength_max":35,"Messages_last_minute":4,"Messages_total":134}}`)
 	fmt.Fprintf(w, "%s\n", towersJSON)
+	ADSBTowerMutex.Unlock()
 }
 
 // AJAX call - /getSatellites. Responds with all GNSS satellites that are being tracked, along with status information.


### PR DESCRIPTION
This is a rollup of stability improvements tested in conjunction with #420. Includes:

- Mutex protection for an unprotected `map[string]ADSBTower `
- Removes a currently unused `products_last_minute` map type
- Array bounds checking on uatdecode.go `DecodeUplink()` function
- Array bounds checking on the (now disabled) `decodeAirmet()` function

