### PR TITLE
Bug fix for logging

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1204,6 +1204,9 @@ func main() {
 		globalStatus.HardwareBuild = "FlightBox"
 		debugLogf = debugLog_FB
 		dataLogFilef = dataLogFile_FB
+	} else { // if not using the FlightBox config, use "normal" log file locations
+		debugLogf = debugLog
+		dataLogFilef = dataLogFile
 	}
 
 	//	replayESFilename := flag.String("eslog", "none", "ES Log filename")


### PR DESCRIPTION
Commit 404a4c9c0 introduced a bug that broke logging for non-FlightBox hardware.

If FlightBox wasn't detected, `debugLogf` `dataLogFilef` were never assigned and remained as nulls. Consequently, the SQLite log and message log were never written to disk, and an error was thrown on the UI status page.

