### PR TITLE
Automatic translation of Mode S codes to US/CA tail numbers

### DIFF
--- a/main/traffic.go
+++ b/main/traffic.go
@@ -13,6 +13,7 @@ import (
 	"bufio"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"log"
 	"math"
 	"net"
@@ -75,7 +76,8 @@ const (
 
 type TrafficInfo struct {
 	Icao_addr           uint32
-	Tail                string
+	Reg                 string    // Registration. Calculated from Icao_addr for civil aircraft of US registry.
+	Tail                string    // Callsign. Transmitted by aircraft.
 	Emitter_category    uint8     // Formatted using GDL90 standard, e.g. in a Mode ES report, A7 becomes 0x07, B0 becomes 0x08, etc.
 	OnGround            bool      // Air-ground status. On-ground is "true".
 	Addr_type           uint8     // UAT address qualifier. Used by GDL90 format, so translations for ES TIS-B/ADS-R are needed.
@@ -349,6 +351,12 @@ func parseDownlinkReport(s string, signalLevel int) {
 		ti.Last_seen = stratuxClock.Time // need to initialize to current stratuxClock so it doesn't get cut before we have a chance to populate a position message
 		ti.Icao_addr = icao_addr
 		ti.ExtrapolatedPosition = false
+
+		thisReg, validReg := icao2faa(icao_addr)
+		if validReg {
+			ti.Reg = thisReg
+			ti.Tail = thisReg
+		}
 	}
 
 	ti.Addr_type = addr_type
@@ -650,6 +658,12 @@ func esListen() {
 				ti.Icao_addr = icao
 				ti.ExtrapolatedPosition = false
 				ti.Last_source = TRAFFIC_SOURCE_1090ES
+
+				thisReg, validReg := icao2faa(icao)
+				if validReg {
+					ti.Reg = thisReg
+					ti.Tail = thisReg
+				}
 			}
 
 			ti.SignalLevel = 10 * math.Log10(newTi.SignalLevel)
@@ -998,6 +1012,104 @@ func updateDemoTraffic(icao uint32, tail string, relAlt float32, gs float64, off
 		registerTrafficUpdate(ti)
 		seenTraffic[ti.Icao_addr] = true
 	}
+}
+
+/*
+	icao2faa() : Converts 24-bit Mode S addresses to N-numbers.
+
+			Input: uint32 representing the Mode S address. Valid range for
+				translation is 0xA00001 - 0xADF7C7, inclusive.
+
+				Values outside the range A000001-AFFFFFF are flagged as non-US.
+				Values between ADF7C8 - AFFFFF are allocated to the United States,
+				but are not used for aicraft on the civil registry. These could be
+				military, other public aircraft, or (future use) temporary
+				anonymous addresses.
+
+			Output:
+				string: String containing the decoded tail number (if decoding succeeded),
+					"NON-US" (for non-US allocation), and "MIL" for non-civil US allocation.
+
+				bool: True if the Mode S address successfully translated to an
+					N number. False for all other conditions.
+*/
+
+func icao2faa(icao_addr uint32) (string, bool) {
+	// Initialize local variables
+	base34alphabet := string("ABCDEFGHJKLMNPQRSTUVWXYZ0123456789")
+	faaOffset := uint32(0xA00001)
+	tail := ""
+
+	// Discard non-US ICAO codes
+	if (icao_addr < 0xA00001) || (icao_addr > 0xAFFFFF) {
+		//fmt.Printf("%X is a non-US address.\n", icao_addr)
+		return "NON-US", false
+	}
+
+	// Discard addresses that are not assigned to aircraft on the civil registry (public aircraft: USAF, USN, USMC, USCG, ANG, FBI, etc.)
+	if icao_addr > 0xADF7C7 {
+		//fmt.Printf("%X is a US aircraft, but not on the civil registry.\n", icao_addr)
+		return "MIL", false
+	}
+
+	serial := int32(icao_addr - faaOffset)
+	// First digit
+	a := (serial / 101711) + 1
+
+	// Second digit
+	a_remainder := serial % 101711
+	b := ((a_remainder + 9510) / 10111) - 1
+
+	// Third digit
+	b_remainder := (a_remainder + 9510) % 10111
+	c := ((b_remainder + 350) / 951) - 1
+
+	// This next bit is more convoluted. First, figure out if we're using the "short" method of
+	// decoding the last two digits (two letters, one letter and one blank, or two blanks).
+	// This will be the case if digit "B" or "C" are calculated as negative, or if c_remainder
+	// is less than 601.
+
+	c_remainder := (b_remainder + 350) % 951
+	var d, e int32
+
+	if (b >= 0) && (c >= 0) && (c_remainder > 600) { // alphanumeric decoding method
+		d = 24 + (c_remainder-601)/35
+		e = (c_remainder - 601) % 35
+
+	} else { // two-letter decoding method
+		if (b < 0) || (c < 0) {
+			c_remainder -= 350 // otherwise "  " == 350, "A " == 351, "AA" == 352, etc.
+		}
+
+		d = (c_remainder - 1) / 25
+		e = (c_remainder - 1) % 25
+
+		if e < 0 {
+			d -= 1
+			e += 25
+		}
+	}
+
+	a_char := fmt.Sprintf("%d", a)
+	var b_char, c_char, d_char, e_char string
+
+	if b >= 0 {
+		b_char = fmt.Sprintf("%d", b)
+	}
+
+	if b >= 0 && c >= 0 {
+		c_char = fmt.Sprintf("%d", c)
+	}
+
+	if d > -1 {
+		d_char = string(base34alphabet[d])
+		if e > 0 {
+			e_char = string(base34alphabet[e-1])
+		}
+	}
+
+	tail = "N" + a_char + b_char + c_char + d_char + e_char
+	return tail, true
 }
 
 func initTraffic() {

--- a/main/traffic.go
+++ b/main/traffic.go
@@ -352,7 +352,7 @@ func parseDownlinkReport(s string, signalLevel int) {
 		ti.Icao_addr = icao_addr
 		ti.ExtrapolatedPosition = false
 
-		thisReg, validReg := icao2faa(icao_addr)
+		thisReg, validReg := icao2reg(icao_addr)
 		if validReg {
 			ti.Reg = thisReg
 			ti.Tail = thisReg
@@ -659,7 +659,7 @@ func esListen() {
 				ti.ExtrapolatedPosition = false
 				ti.Last_source = TRAFFIC_SOURCE_1090ES
 
-				thisReg, validReg := icao2faa(icao)
+				thisReg, validReg := icao2reg(icao)
 				if validReg {
 					ti.Reg = thisReg
 					ti.Tail = thisReg
@@ -1015,100 +1015,143 @@ func updateDemoTraffic(icao uint32, tail string, relAlt float32, gs float64, off
 }
 
 /*
-	icao2faa() : Converts 24-bit Mode S addresses to N-numbers.
+	icao2reg() : Converts 24-bit Mode S addresses to N-numbers and C-numbers.
 
 			Input: uint32 representing the Mode S address. Valid range for
 				translation is 0xA00001 - 0xADF7C7, inclusive.
 
-				Values outside the range A000001-AFFFFFF are flagged as non-US.
+				Values outside the range A000001-AFFFFFF or C00001-C3FFFF
+				are flagged as foreign.
+
 				Values between ADF7C8 - AFFFFF are allocated to the United States,
 				but are not used for aicraft on the civil registry. These could be
-				military, other public aircraft, or (future use) temporary
-				anonymous addresses.
+				military, other public aircraft, or future use.
+
+
+				Values between C0CDF9 - C3FFFF are allocated to Canada,
+				but are not used for aicraft on the civil registry. These could be
+				military, other public aircraft, or future use.
 
 			Output:
 				string: String containing the decoded tail number (if decoding succeeded),
-					"NON-US" (for non-US allocation), and "MIL" for non-civil US allocation.
+					"NON-NA" (for non-US / non Canada allocation), and "US-MIL" or "CA-MIL" for non-civil US / Canada allocation.
 
 				bool: True if the Mode S address successfully translated to an
 					N number. False for all other conditions.
 */
 
-func icao2faa(icao_addr uint32) (string, bool) {
+func icao2reg(icao_addr uint32) (string, bool) {
 	// Initialize local variables
 	base34alphabet := string("ABCDEFGHJKLMNPQRSTUVWXYZ0123456789")
-	faaOffset := uint32(0xA00001)
+	nationalOffset := uint32(0xA00001) // default is US
 	tail := ""
+	nation := ""
 
-	// Discard non-US ICAO codes
-	if (icao_addr < 0xA00001) || (icao_addr > 0xAFFFFF) {
-		//fmt.Printf("%X is a non-US address.\n", icao_addr)
-		return "NON-US", false
+	// Determine nationality
+	if (icao_addr >= 0xA00001) && (icao_addr <= 0xAFFFFF) {
+		nation = "US"
+	} else if (icao_addr >= 0xC00001) && (icao_addr <= 0xC3FFFF) {
+		nation = "CA"
+	} else {
+		// future national decoding is TO-DO
+		return "NON-NA", false
 	}
 
-	// Discard addresses that are not assigned to aircraft on the civil registry (public aircraft: USAF, USN, USMC, USCG, ANG, FBI, etc.)
-	if icao_addr > 0xADF7C7 {
-		//fmt.Printf("%X is a US aircraft, but not on the civil registry.\n", icao_addr)
-		return "MIL", false
-	}
-
-	serial := int32(icao_addr - faaOffset)
-	// First digit
-	a := (serial / 101711) + 1
-
-	// Second digit
-	a_remainder := serial % 101711
-	b := ((a_remainder + 9510) / 10111) - 1
-
-	// Third digit
-	b_remainder := (a_remainder + 9510) % 10111
-	c := ((b_remainder + 350) / 951) - 1
-
-	// This next bit is more convoluted. First, figure out if we're using the "short" method of
-	// decoding the last two digits (two letters, one letter and one blank, or two blanks).
-	// This will be the case if digit "B" or "C" are calculated as negative, or if c_remainder
-	// is less than 601.
-
-	c_remainder := (b_remainder + 350) % 951
-	var d, e int32
-
-	if (b >= 0) && (c >= 0) && (c_remainder > 600) { // alphanumeric decoding method
-		d = 24 + (c_remainder-601)/35
-		e = (c_remainder - 601) % 35
-
-	} else { // two-letter decoding method
-		if (b < 0) || (c < 0) {
-			c_remainder -= 350 // otherwise "  " == 350, "A " == 351, "AA" == 352, etc.
+	if nation == "CA" { // Canada decoding
+		// First, discard addresses that are not assigned to aircraft on the civil registry
+		if icao_addr > 0xC0CDF8 {
+			//fmt.Printf("%X is a Canada aircraft, but not a CF-, CG-, or CI- registration.\n", icao_addr)
+			return "CA-MIL", false
 		}
 
-		d = (c_remainder - 1) / 25
-		e = (c_remainder - 1) % 25
+		nationalOffset := uint32(0xC00001)
+		serial := int32(icao_addr - nationalOffset)
 
-		if e < 0 {
-			d -= 1
-			e += 25
+		// Fifth letter
+		e := serial % 26
+
+		// Fourth letter
+		d := (serial / 26) % 26
+
+		// Third letter
+		c := (serial / 676) % 26 // 676 == 26*26
+
+		// Second letter
+		b := (serial / 17576) % 26 // 17576 == 26*26*26
+
+		b_str := "FGI"
+
+		//fmt.Printf("B = %d, C = %d, D = %d, E = %d\n",b,c,d,e)
+		tail = fmt.Sprintf("C%c%c%c%c", b_str[b], c+65, d+65, e+65)
+	}
+
+	if nation == "US" { // FAA decoding
+		// First, discard addresses that are not assigned to aircraft on the civil registry
+		if icao_addr > 0xADF7C7 {
+			//fmt.Printf("%X is a US aircraft, but not on the civil registry.\n", icao_addr)
+			return "US-MIL", false
 		}
-	}
 
-	a_char := fmt.Sprintf("%d", a)
-	var b_char, c_char, d_char, e_char string
+		serial := int32(icao_addr - nationalOffset)
+		// First digit
+		a := (serial / 101711) + 1
 
-	if b >= 0 {
-		b_char = fmt.Sprintf("%d", b)
-	}
+		// Second digit
+		a_remainder := serial % 101711
+		b := ((a_remainder + 9510) / 10111) - 1
 
-	if b >= 0 && c >= 0 {
-		c_char = fmt.Sprintf("%d", c)
-	}
+		// Third digit
+		b_remainder := (a_remainder + 9510) % 10111
+		c := ((b_remainder + 350) / 951) - 1
 
-	if d > -1 {
-		d_char = string(base34alphabet[d])
-		if e > 0 {
-			e_char = string(base34alphabet[e-1])
+		// This next bit is more convoluted. First, figure out if we're using the "short" method of
+		// decoding the last two digits (two letters, one letter and one blank, or two blanks).
+		// This will be the case if digit "B" or "C" are calculated as negative, or if c_remainder
+		// is less than 601.
+
+		c_remainder := (b_remainder + 350) % 951
+		var d, e int32
+
+		if (b >= 0) && (c >= 0) && (c_remainder > 600) { // alphanumeric decoding method
+			d = 24 + (c_remainder-601)/35
+			e = (c_remainder - 601) % 35
+
+		} else { // two-letter decoding method
+			if (b < 0) || (c < 0) {
+				c_remainder -= 350 // otherwise "  " == 350, "A " == 351, "AA" == 352, etc.
+			}
+
+			d = (c_remainder - 1) / 25
+			e = (c_remainder - 1) % 25
+
+			if e < 0 {
+				d -= 1
+				e += 25
+			}
 		}
+
+		a_char := fmt.Sprintf("%d", a)
+		var b_char, c_char, d_char, e_char string
+
+		if b >= 0 {
+			b_char = fmt.Sprintf("%d", b)
+		}
+
+		if b >= 0 && c >= 0 {
+			c_char = fmt.Sprintf("%d", c)
+		}
+
+		if d > -1 {
+			d_char = string(base34alphabet[d])
+			if e > 0 {
+				e_char = string(base34alphabet[e-1])
+			}
+		}
+
+		tail = "N" + a_char + b_char + c_char + d_char + e_char
+
 	}
 
-	tail = "N" + a_char + b_char + c_char + d_char + e_char
 	return tail, true
 }
 

--- a/test/icao2reg.go
+++ b/test/icao2reg.go
@@ -1,0 +1,177 @@
+/*
+
+	icao2reg: Converts a 24-bit numeric value to a tail number of FAA
+    or Canadian registry.
+	
+	(c) 2016 AvSquirrel
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights to
+	use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+	of the Software, and to permit persons to whom the Software is furnished to do
+	so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in all
+	copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+	WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+	CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+func main() {
+	icao := uint32(0xAC82EC)
+	args := os.Args
+	if len(args) > 1 {
+		code, err := strconv.ParseInt(args[1], 16, 32)
+		if err != nil {
+			fmt.Printf("Error parsing argument %s. Input should be 24-bit hexadecimal, e.g. 'A00001'\n", args[1])
+			fmt.Printf("Showing example decoding for Mode S code %X,\n", icao)
+		} else {
+			icao = uint32(code)
+		}
+	} else {
+		fmt.Printf("Usage: ./icao2faa [code], where [code] is a 24-bit hexadecimal string, e.g. A00001\n")
+		fmt.Printf("Showing example decoding for Mode S code %X,\n", icao)
+	}
+
+	tail, valid := icao2reg(icao)
+
+	if valid {
+		fmt.Printf("ICAO %X successfully decodes as %s\n", icao, tail)
+	} else {
+		fmt.Printf("ICAO %X did not successfully decode. Response is `%s`\n", icao, tail)
+	}
+}
+
+func icao2reg(icao_addr uint32) (string, bool) {
+	// Initialize local variables
+	base34alphabet := string("ABCDEFGHJKLMNPQRSTUVWXYZ0123456789")
+	nationalOffset := uint32(0xA00001) // default is US
+	tail := ""
+	nation := ""
+	
+	
+	// Determine nationality
+	if (icao_addr >= 0xA00001) && (icao_addr <= 0xAFFFFF) {
+		nation = "US"
+	} else if (icao_addr >= 0xC00001) && (icao_addr <= 0xC3FFFF) {
+		nation = "CA"
+	} else {
+		// future national decoding is TO-DO
+		return "NON-NA", false
+	}
+
+	if (nation =="CA") { // Canada decoding
+		// First, discard addresses that are not assigned to aircraft on the civil registry
+		if icao_addr > 0xC0CDF8 {
+			//fmt.Printf("%X is a Canada aircraft, but not a CF-, CG-, or CI- registration.\n", icao_addr)
+			return "CA-MIL", false
+		}
+	
+		nationalOffset := uint32(0xC00001)
+		serial := int32(icao_addr - nationalOffset)
+		
+		// Fifth letter
+		e := serial % 26
+		
+		// Fourth letter
+		d := (serial/26) % 26
+		
+		// Third letter
+		c := (serial/676) % 26 // 676 == 26*26
+	
+		// Second letter
+		b := (serial/17576) % 26 // 17576 == 26*26*26
+	
+		b_str :="FGI"
+		
+		fmt.Printf("B = %d, C = %d, D = %d, E = %d\n",b,c,d,e)
+		tail = fmt.Sprintf("C%c%c%c%c",b_str[b],c+65,d+65,e+65)
+	}
+	
+	if (nation == "US") { // FAA decoding
+		// First, discard addresses that are not assigned to aircraft on the civil registry
+		if icao_addr > 0xADF7C7 {
+			//fmt.Printf("%X is a US aircraft, but not on the civil registry.\n", icao_addr)
+			return "US-MIL", false
+		}
+
+
+	serial := int32(icao_addr - nationalOffset)
+		// First digit
+		a := (serial / 101711) + 1
+
+		// Second digit
+		a_remainder := serial % 101711
+		b := ((a_remainder + 9510) / 10111) - 1
+
+		// Third digit
+		b_remainder := (a_remainder + 9510) % 10111
+		c := ((b_remainder + 350) / 951) - 1
+
+		// This next bit is more convoluted. First, figure out if we're using the "short" method of
+		// decoding the last two digits (two letters, one letter and one blank, or two blanks).
+		// This will be the case if digit "B" or "C" are calculated as negative, or if c_remainder
+		// is less than 601.
+
+		c_remainder := (b_remainder + 350) % 951
+		var d, e int32
+
+		if (b >= 0) && (c >= 0) && (c_remainder > 600) { // alphanumeric decoding method
+			d = 24 + (c_remainder-601)/35
+			e = (c_remainder - 601) % 35
+
+		} else { // two-letter decoding method
+			if (b < 0) || (c < 0) {
+				c_remainder -= 350 // otherwise "  " == 350, "A " == 351, "AA" == 352, etc.
+			}
+
+			d = (c_remainder - 1) / 25
+			e = (c_remainder - 1) % 25
+
+			if e < 0 {
+				d -= 1
+				e += 25
+			}
+		}
+
+		a_char := fmt.Sprintf("%d", a)
+		var b_char, c_char, d_char, e_char string
+
+		if b >= 0 {
+			b_char = fmt.Sprintf("%d", b)
+		}
+
+		if b >= 0 && c >= 0 {
+			c_char = fmt.Sprintf("%d", c)
+		}
+
+		if d > -1 {
+			d_char = string(base34alphabet[d])
+			if e > 0 {
+				e_char = string(base34alphabet[e-1])
+			}
+		}
+
+
+		tail = "N" + a_char + b_char + c_char + d_char + e_char
+	
+	}
+	
+	
+	return tail, true
+}

--- a/web/plates/js/traffic.js
+++ b/web/plates/js/traffic.js
@@ -59,6 +59,7 @@ function TrafficCtrl($rootScope, $scope, $state, $http, $interval) {
 		}
 		new_traffic.icao = obj.Icao_addr.toString(16).toUpperCase();
 		new_traffic.tail = obj.Tail;
+		new_traffic.reg = obj.Reg;
 		if (obj.Squawk == 0) {
 			new_traffic.squawk = "----";
 		} else {

--- a/web/plates/traffic.html
+++ b/web/plates/traffic.html
@@ -9,7 +9,8 @@
 		<div class="panel-body traffic-page">
 			<div class="row">
 				<div class="col-sm-6">
-					<span class="col-xs-3"><strong>Callsign</strong></span>
+					<span class="col-xs-3" ng-hide="showReg"><strong>Callsign</strong></span>
+					<span class="col-xs-3" ng-show="showReg"><strong>Tail Num</strong></span>
 					<span class="col-xs-2" ng-hide="showSquawk"><strong>Code</strong></span>
 					<span class="col-xs-2" ng-show="showSquawk"><strong>Squawk</strong></span>
 					<span class="col-xs-5 text-right" ng-hide="GPS_connected && RelDist"><strong>Location</strong></span>
@@ -29,11 +30,15 @@
 			<div class="row" ng-repeat="aircraft in data_list | orderBy: 'dist'">
 				<div class="separator"></div>
 				<div class="col-sm-6">
-					<span class="col-xs-3">
+					<span class="col-xs-3" ng-hide="showReg">
 						<span ng-show="aircraft.tail" ng-class="'label traffic-style'+aircraft.src+aircraft.targettype">{{aircraft.addr_symb}}<strong>&nbsp;{{aircraft.tail}}</strong></span>
 						<span ng-hide="aircraft.tail" ng-class="'label traffic-style'+aircraft.src+aircraft.targettype">{{aircraft.addr_symb}}<strong>&nbsp;[--N/A--]</strong></span>
+					</span>					
+					<span class="col-xs-3" ng-show="showReg">
+						<span ng-show="aircraft.reg" ng-class="'label traffic-style'+aircraft.src+aircraft.targettype">{{aircraft.addr_symb}}<strong>&nbsp;{{aircraft.reg}}</strong></span>
+						<span ng-hide="aircraft.reg" ng-class="'label traffic-style'+aircraft.src+aircraft.targettype">{{aircraft.addr_symb}}<strong>&nbsp;[--N/A--]</strong></span>
 					</span>
-				
+
 					<span class="col-xs-2">
 						<span style="font-size:80%" ng-hide="showSquawk">{{aircraft.icao}}<span style="font-size:50%">{{aircraft.addr_type == 3 ? "&nbsp;(TFID)" : ""}}</span></span>
 						<span ng-show="showSquawk"><span ng-show="aircraft.squawk < 1000">0</span><span ng-show="aircraft.squawk < 100">0</span><span ng-show="aircraft.squawk < 10">0</span>{{aircraft.squawk}}</span>
@@ -61,18 +66,25 @@
 			<div class="separator"></div>
 			<div class="row">
 				<div class="col-sm-4">
+					<label class="control-label col-xs-6">Show Tail Number</label>
+					<span class="col-xs-3"><ui-switch ng-model='showReg' settings-change></ui-switch></span>
+				</div>
+				<div class="col-sm-4">
 					<label class="control-label col-xs-6">Show Squawk</label>
 					<span class="col-xs-3"><ui-switch ng-model='showSquawk' settings-change></ui-switch></span>
 				</div>
 				<div class="col-sm-4">
-					<label class="control-label col-xs-6">Show Distance</label>
+					<label class="control-label col-xs-6" ng-show="GPS_connected">Show Distance</label>
+					<label class="control-label text-muted col-xs-6" ng-hide="GPS_connected">Show Distance N/A</label>
 					<span class="col-xs-3"><ui-switch ng-model='RelDist' settings-change></ui-switch></span>
 				</div>
+				<!--
 				<div class="col-sm-4">
 					<label class="control-label col-xs-6">GPS Status</label>
 					<span ng-show="GPS_connected" class="label label-success col-xs-3" style="font-size:100%; display:block; height: 34px; line-height: 34px">Valid</span>
 					<span ng-hide="GPS_connected" class="label label-danger col-xs-3" style="font-size:100%; display:block; height: 34px; line-height: 34px">No Fix</span>
 				</div>
+				-->
 			</div>
 		</div>
 	</div>
@@ -85,7 +97,8 @@
 		<div class="panel-body traffic-page">
 			<div class="row">
 				<div class="col-sm-6">
-					<span class="col-xs-4"><strong>Callsign</strong></span>
+					<span class="col-xs-4" ng-hide="showReg"><strong>Callsign</strong></span>
+					<span class="col-xs-4" ng-show="showReg"><strong>Tail Num</strong></span>
 					<span class="col-xs-3"><strong>Code</strong></span>
 					<span class="col-xs-3"><strong>Squawk</strong></span>
 				</div>
@@ -102,9 +115,13 @@
 			<div class="row" ng-repeat="aircraft in data_list_invalid | orderBy: 'icao'">
 				<div class="separator"></div>
 				<div class="col-sm-6">
-					<span class="col-xs-4">
+					<span class="col-xs-4" ng-hide="showReg">
 						<span ng-show="aircraft.tail" ng-class="'label traffic-style'+aircraft.src+aircraft.targettype">{{aircraft.addr_symb}}<strong>&nbsp;{{aircraft.tail}}</strong></span>
 						<span ng-hide="aircraft.tail" ng-class="'label traffic-style'+aircraft.src+aircraft.targettype">{{aircraft.addr_symb}}<strong>&nbsp;[--N/A--]</strong></span>
+					</span>					
+					<span class="col-xs-4" ng-show="showReg">
+						<span ng-show="aircraft.reg" ng-class="'label traffic-style'+aircraft.src+aircraft.targettype">{{aircraft.addr_symb}}<strong>&nbsp;{{aircraft.reg}}</strong></span>
+						<span ng-hide="aircraft.reg" ng-class="'label traffic-style'+aircraft.src+aircraft.targettype">{{aircraft.addr_symb}}<strong>&nbsp;[--N/A--]</strong></span>
 					</span>
 					<span class="col-xs-3" style="font-size:80%">{{aircraft.icao}}<span style="font-size:50%">{{aircraft.addr_type == 3 ? "&nbsp;(TFID)" : ""}}</span></span>
 					<span class="col-xs-3"><span ng-show="aircraft.squawk < 1000">0</span><span ng-show="aircraft.squawk < 100">0</span><span ng-show="aircraft.squawk < 10">0</span>{{aircraft.squawk}}</span>


### PR DESCRIPTION
There was some discussion a few months back (#298) about goofy callsigns being transmitted by certain aircraft: "00000000", "N", and everyone's favorite, "BWIFATTY". Consensus was that those callsigns were intentionally entered into the FMS by their flightcrews, and there was some discussion about either filtering "unusual" callsigns, or translating the Mode S code to determine the actual tail number. This is an implementation of the latter.

In both the United States and Canada, civil aircraft registrations (N-number and C-numbers) are related to the 24-bit Mode S code through a 1-to-1 mathematical relationship. In other words, given a specific 24-bit code, it is possible to determine what tail number it belongs to, and vice versa.

The method for calculating US/CAN registrations is implemented in the following way:
- Each time a traffic message is decoded, `parseDownlinkReport()` or `esListen()` checks the `traffic[]` structure to determine if that Mode S code is being tracked. If not, a new traffic object is initialized -- this is current Stratux behavior.
- This change adds a call to a new `icao2reg()` function during traffic object initialization.
- `icao2reg` determines if the Mode S code is in the correct range for US / Canada civil registrations, and if so, decodes it to a registration code. That code is returned as a string.
- Upon successful decoding, the registration code is assigned to both `ti.Tail` (callsign) and a new `ti.Reg` variable (registration).
- Subsequent ADS-B traffic messages will typically provide callsign information; at that point, `ti.Tail` will be overwritten with whichever callsign the aircraft is broadcasting, and will be used for the GDL90 output. However, `ti.Reg` will retain the registration code for that aircraft.
- Traffic UI by default will still show callsign (`ti.Tail`). A toggle has been added to allow the decoded registration (`ti.Reg`) to be shown.
- "Show Distance" toggle has also been cleaned up to remove the "GPS Connected" indicator. If GPS disconnects, the text will change to "Show Distance N/A"  and will be grayed out. Addresses #426.

![image](https://cloud.githubusercontent.com/assets/14127245/16197497/e2434180-36c7-11e6-8417-00ac0f6964b1.png)

![image](https://cloud.githubusercontent.com/assets/14127245/16197504/e81e97bc-36c7-11e6-9b6d-1e449095514b.png)
