### PR TITLE
interface to dump1090 library build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dump978/uat2json
 dump978/uat2text
 gen_gdl90
 libdump978.so
+libdump1090.so
 
 *.mp4
 

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,12 @@ xgen_gdl90:
 
 xdump1090:
 	git submodule update --init
-	cd dump1090 && make
+	cd dump1090 && make lib
+	cp -f ./libdump1090.so /usr/lib/libdump1090.so
 
 xdump978:
 	cd dump978 && make lib
-	sudo cp -f ./libdump978.so /usr/lib/libdump978.so
+	cp -f ./libdump978.so /usr/lib/libdump978.so
 
 xlinux-mpu9150:
 	git submodule update --init
@@ -49,7 +50,7 @@ install:
 	cp -f dump1090/dump1090 /usr/bin/
 
 clean:
-	rm -f gen_gdl90 libdump978.so
+	rm -f gen_gdl90 libdump978.so libdump1090.so
 	cd dump1090 && make clean
 	cd dump978 && make clean
 	rm -f linux-mpu9150/*.o linux-mpu9150/*.so

--- a/main/sdr.go
+++ b/main/sdr.go
@@ -4,6 +4,8 @@
 	that can be found in the LICENSE file, herein included
 	as part of this header.
 
+	Modifications (c) 2015-2016 Joseph D Poirier (https://github.com/jpoirier)
+
 	sdr.go: SDR monitoring, SDR management, data input from UAT/1090ES channels.
 */
 


### PR DESCRIPTION
The go and dump1090 code required only small changes and the sdr handling is simpler and a bit faster now.  The way gen_gdl90 interfaces to dump1090 for info doesn't change in any way nor does the dump1090 structure/functionality-onlysdr.go and dum1090.c have been modified.  What changes is the way we command/drive the dump1090 process. Previously we spawned the binary and passed it parameters whereas with the a shared library we call in to it and let it run.  When built as a binary, main does some setup and drops in to a while loop until exit, with the library we spawn a renamed, and simplified, main in a thread and let it run.

We add three new functions to dump1090.c  (start1090, stop1090, stratuxLog), rename main to start_main, and export the function log1090 from Go. In the sdr.go file when ES config is called we call C.start1090, passing it the dongle index to config and a ppm value, spawn start_main in a thread and return. When ES shutdown is called we call C.stop1090, which sets a flag telling start_main to exit, and once start_main exits stop1090 returns. For logging, when dump1090 is compiled as a lib there's a FPRINTF macro that calls stratuxLog which in turn calls log1090 so message strings get written to the stratux log.

edited: tested (en/dis-abling 978/1090, etc...) on an rpi that ran for a full 24 hours