### PR TITLE
GPS accuracy on Status page

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -707,7 +707,7 @@ func cpuTempMonitor() {
 
 func updateStatus() {
 	if mySituation.Quality == 2 {
-		globalStatus.GPS_solution = "GPS + SBAS (WAAS / EGNOS)"
+		globalStatus.GPS_solution = "GPS + SBAS (WAAS)"
 	} else if mySituation.Quality == 1 {
 		globalStatus.GPS_solution = "3D GPS"
 	} else if mySituation.Quality == 6 {
@@ -735,6 +735,7 @@ func updateStatus() {
 	globalStatus.GPS_satellites_locked = mySituation.Satellites
 	globalStatus.GPS_satellites_seen = mySituation.SatellitesSeen
 	globalStatus.GPS_satellites_tracked = mySituation.SatellitesTracked
+	globalStatus.GPS_position_accuracy = mySituation.Accuracy
 
 	// Update Uptime value
 	globalStatus.Uptime = int64(stratuxClock.Milliseconds)
@@ -973,6 +974,7 @@ type status struct {
 	GPS_satellites_locked                      uint16
 	GPS_satellites_seen                        uint16
 	GPS_satellites_tracked                     uint16
+	GPS_position_accuracy                      float32
 	GPS_connected                              bool
 	GPS_solution                               string
 	RY835AI_connected                          bool

--- a/web/plates/js/status.js
+++ b/web/plates/js/status.js
@@ -53,6 +53,7 @@ function StatusCtrl($rootScope, $scope, $state, $http, $interval) {
 			$scope.GPS_satellites_tracked = status.GPS_satellites_tracked;
 			$scope.GPS_satellites_seen = status.GPS_satellites_seen;
 			$scope.GPS_solution = status.GPS_solution;
+			$scope.GPS_position_accuracy = String(status.GPS_solution ? ", " + status.GPS_position_accuracy.toFixed(1) : "");
 			$scope.RY835AI_connected = status.RY835AI_connected;
 			var tempClock = new Date(Date.parse(status.Clock));
 			var clockString = tempClock.toUTCString();
@@ -66,7 +67,7 @@ function StatusCtrl($rootScope, $scope, $state, $http, $interval) {
 				$scope.visible_errors = true;
 				$scope.Errors = status.Errors;
 			}
-			
+
 			var uptime = status.Uptime;
 			if (uptime != undefined) {
 				var up_d = parseInt((uptime/1000) / 86400),

--- a/web/plates/status.html
+++ b/web/plates/status.html
@@ -68,7 +68,7 @@
 				</div>
 				<div class="row" ng-class="{'section_invisible': !visible_gps}">
 					<label class="col-xs-6">GPS solution:</label>
-					<span class="col-xs-6">{{GPS_solution}}</span>
+					<span class="col-xs-6">{{GPS_solution}}{{GPS_position_accuracy}}</span>
 				</div>
 				<div class="row" ng-class="{'section_invisible': !visible_gps}">
 					<label class="col-xs-6">GPS satellites:</label>


### PR DESCRIPTION
This is a really simple tweak based on something I noticed in my testing use case.

I've been doing some device testing, and it's useful to know the accuracy of the GPS without tapping around and losing the ability to see messages/min for UAT/1090, etc.

This adds `mySituation.Accuracy` to the output of `updateStatus`, and handles it on the front end. To keep from linewrapping on small screens, I simplified `WAAS / EGNOS` to just `WAAS`, although I could see this being less than good. If it's requested, I can probably fiddle with the layout of that component and create more space on the values side; there's room to take away from the labels.

I'm new to playing around in the angular side - let me know if I'm doing Bad Things by manipulating this into a String or something!

<img width="376" alt="screenshot 2016-07-15 00 49 19" src="https://cloud.githubusercontent.com/assets/1148896/16867312/fd6f2bba-4a25-11e6-9d72-e8df13407d37.png">
