### PR TITLE
Clean out clock UI

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -739,7 +739,6 @@ func updateStatus() {
 	// Update Uptime value
 	globalStatus.Uptime = int64(stratuxClock.Milliseconds)
 	globalStatus.UptimeClock = stratuxClock.Time
-	globalStatus.Clock = time.Now()
 
 	usage = du.NewDiskUsage("/")
 	globalStatus.DiskBytesFree = usage.Free()
@@ -977,7 +976,6 @@ type status struct {
 	GPS_solution                               string
 	RY835AI_connected                          bool
 	Uptime                                     int64
-	Clock                                      time.Time
 	UptimeClock                                time.Time
 	CPUTemp                                    float32
 	NetworkDataMessagesSent                    uint64

--- a/web/plates/js/status.js
+++ b/web/plates/js/status.js
@@ -40,7 +40,7 @@ function StatusCtrl($rootScope, $scope, $state, $http, $interval) {
 			console.log('Received status update.')
 
 			var status = JSON.parse(msg.data)
-				// Update Status
+			// Update Status
 			$scope.Version = status.Version;
 			$scope.Build = status.Build.substr(0, 10);
 			$scope.Devices = status.Devices;
@@ -54,19 +54,13 @@ function StatusCtrl($rootScope, $scope, $state, $http, $interval) {
 			$scope.GPS_satellites_seen = status.GPS_satellites_seen;
 			$scope.GPS_solution = status.GPS_solution;
 			$scope.RY835AI_connected = status.RY835AI_connected;
-			var tempClock = new Date(Date.parse(status.Clock));
-			var clockString = tempClock.toUTCString();
-			$scope.Clock = clockString;
-			var tempLocalClock = new Date;
-			$scope.LocalClock = tempLocalClock.toUTCString();
-			$scope.SecondsFast = (Math.round(tempClock-tempLocalClock)/1000).toFixed(2);
 
 			// Errors array.
 			if (status.Errors.length > 0) {
 				$scope.visible_errors = true;
 				$scope.Errors = status.Errors;
 			}
-			
+
 			var uptime = status.Uptime;
 			if (uptime != undefined) {
 				var up_d = parseInt((uptime/1000) / 86400),

--- a/web/plates/status.html
+++ b/web/plates/status.html
@@ -93,22 +93,6 @@
 						<span class="col-xs-7">{{CPUTemp}}</span>
 					</div>
 				</div>
-
-				<div class="separator"></div>
-				<div class="row">
-					<div class="col-sm-4 label_adj">
-						<span class="col-xs-4"><strong>Stratux Clock:</strong></span>
-						<span class="col-xs-8">{{Clock}}</span>
-					</div>
-					<div class="col-sm-4 label_adj">
-						<span class="col-xs-4"><strong>Device Clock:</strong></span>
-						<span class="col-xs-8">{{LocalClock}}</span>
-					</div>
-					<div class="col-sm-4 label_adj">
-						<span class="col-xs-4"><strong>Difference:</strong></span>
-						<span class="col-xs-8">{{SecondsFast}} sec</span>
-					</div>
-				</div>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
This removes the clock from the UI (js, template) and the .go status result, part of enhancement #426.