### PR TITLE
Update setup scripts to disable console on ttyAMA0

### DIFF
--- a/image/mkimg.sh
+++ b/image/mkimg.sh
@@ -113,7 +113,6 @@ make
 make install
 
 #disable serial console
-sed -i /etc/inittab -e "s|^.*:.*:respawn:.*ttyAMA0|#&|"
 sed -i /boot/cmdline.txt -e "s/console=ttyAMA0,[0-9]\+ //"
 
 #Set the keyboard layout to US.

--- a/image/mkimg.sh
+++ b/image/mkimg.sh
@@ -114,6 +114,7 @@ make install
 
 #disable serial console
 sed -i /etc/inittab -e "s|^.*:.*:respawn:.*ttyAMA0|#&|"
+sed -i /boot/cmdline.txt -e "s/console=ttyAMA0,[0-9]\+ //"
 
 #Set the keyboard layout to US.
 sed -i /etc/default/keyboard -e "/^XKBLAYOUT/s/\".*\"/\"us\"/"

--- a/selfupdate/update_footer.sh
+++ b/selfupdate/update_footer.sh
@@ -30,7 +30,6 @@ cp -f hostapd_manager.sh /usr/sbin/
 cp -f config.txt /boot/config.txt
 
 #disable serial console
-sed -i /etc/inittab -e "s|^.*:.*:respawn:.*ttyAMA0|#&|"
 sed -i /boot/cmdline.txt -e "s/console=ttyAMA0,[0-9]\+ //"
 
 #modprobe.d blacklist

--- a/selfupdate/update_footer.sh
+++ b/selfupdate/update_footer.sh
@@ -29,6 +29,10 @@ cp -f hostapd_manager.sh /usr/sbin/
 #boot config
 cp -f config.txt /boot/config.txt
 
+#disable serial console
+sed -i /etc/inittab -e "s|^.*:.*:respawn:.*ttyAMA0|#&|"
+sed -i /boot/cmdline.txt -e "s/console=ttyAMA0,[0-9]\+ //"
+
 #modprobe.d blacklist
 cp -f rtl-sdr-blacklist.conf /etc/modprobe.d/
 


### PR DESCRIPTION
See #400.

This updates two setup scripts (mkimg.sh and update_footer.sh) to look for and remove any `console=ttyAMA0` references in `/boot/cmdline.txt`, resolving a serial connection issue that caused USB receivers to be unable to connect if installed after boot, and for intermittent disconnects of GPS receivers connected over serial GPIO. 

This also removes an outdated reference to `/etc/inittab` in mkimg.sh.

