### PR TITLE
Gdl90report

### DIFF
--- a/main/network.go
+++ b/main/network.go
@@ -135,7 +135,11 @@ func sendToAllConnectedClients(msg networkMessage) {
 			if sleepFlag {
 				continue
 			}
-			netconn.Conn.Write(msg.msg) // Write immediately.
+			_, err := netconn.Conn.Write(msg.msg) // Write immediately.
+			if err != nil {
+				//TODO: Maybe we should drop the client?  Retry first?
+				log.Printf("GDL Message error: %s\n", err.Error())
+			}
 			totalNetworkMessagesSent++
 			globalStatus.NetworkDataMessagesSent++
 			globalStatus.NetworkDataMessagesSentNonqueueable++

--- a/main/ry835ai.go
+++ b/main/ry835ai.go
@@ -1419,15 +1419,24 @@ func makeAHRSGDL90Report() {
 	msg[2] = 0x01
 	msg[3] = 0x01
 
-	pitch := int16(mySituation.Pitch*10)
-	roll := int16(mySituation.Roll*10)
-	hdg := int16(mySituation.Gyro_heading*10)
-	slip_skid := int16(mySituation.SlipSkid*10)
-	yaw_rate := int16(mySituation.RateOfTurn*10)
-	g := int16(mySituation.GLoad*10)
+	// Values if invalid
+	pitch := int16(0x7FFF)
+	roll := int16(0x7FFF)
+	hdg := int16(0x7FFF)
+	slip_skid := int16(0x7FFF)
+	yaw_rate := int16(0x7FFF)
+	g := int16(0x7FFF)
 	airspeed := int16(0x7FFF)	             // Can add this once we can read airspeed
-	palt := uint16(0xFFFF)                       // Value if invalid
-	vs := int16(0x7FFF)                          // Value if invalid
+	palt := uint16(0xFFFF)
+	vs := int16(0x7FFF)
+	if isAHRSValid() {
+		pitch = int16(mySituation.Pitch * 10)
+		roll = int16(mySituation.Roll * 10)
+		hdg = int16(mySituation.Gyro_heading * 10)
+		slip_skid = int16(mySituation.SlipSkid * 10)
+		yaw_rate = int16(mySituation.RateOfTurn * 10)
+		g = int16(mySituation.GLoad * 10)
+	}
 	if isTempPressValid() {
 		palt = uint16(mySituation.Pressure_alt + 5000)
 		vs = int16(mySituation.RateOfClimb)


### PR DESCRIPTION
This PR is for upgrading the GDL90Report to iLevil's report Package ID Version 1 (current version implemented in stratux is 0).  This adds a few more fields to the report: airspeed, pressure altitude and vertical speed.  Version 1 is the currently supported version in DroidEFB (version 0 wouldn't work; an upgrade was just released today that works with version 1).

This PR is in preparation for AHRS support, so it also adds Slip/Skid, Turn Rate, and GLoad to the stratux Situation struct so they will be automatically sent.

Attitude output tested with DroidEFB and Naviator.  I was unable to find an app that would report pressure altitude from the GDL90Report stream, and I don't have an Apple device to test, so would appreciate if someone with an iPad could test before merging (test both altitude/rate of climb reception and correct communication with Foreflight etc.).  Output looks correct when viewed with netcat, however.

This is my first PR, so I thought I would keep it limited and simple.  Thanks!
