### PR TITLE
Use ReplayLog data to create KML files of both traffic and ownship

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all:
 
 xgen_gdl90:
 	go get -t -d -v ./main ./test ./linux-mpu9150/mpu ./godump978 ./mpu6050 ./uatparse
-	go build $(BUILDINFO) -p 4 main/gen_gdl90.go main/traffic.go main/ry835ai.go main/network.go main/managementinterface.go main/sdr.go main/uibroadcast.go main/monotonic.go main/datalog.go main/equations.go
+	go build $(BUILDINFO) -p 4 main/gen_gdl90.go main/traffic.go main/ry835ai.go main/network.go main/export_datalog.go main/managementinterface.go main/sdr.go main/uibroadcast.go main/monotonic.go main/datalog.go main/equations.go
 
 xdump1090:
 	git submodule update --init

--- a/main/datalog.go
+++ b/main/datalog.go
@@ -532,7 +532,7 @@ func isDataLogReady() bool {
 }
 
 func logSituation() {
-	if globalSettings.ReplayLog && isDataLogReady() {
+	if (globalSettings.ReplayLog || globalSettings.GPS_Track_Enabled) && isDataLogReady() {
 		dataLogChan <- DataLogRow{tbl: "mySituation", data: mySituation}
 	}
 }
@@ -593,10 +593,10 @@ func initDataLog() {
 
 func dataLogWatchdog() {
 	for {
-		if !dataLogStarted && globalSettings.ReplayLog { // case 1: sqlite logging isn't running, and we want to start it
+		if !dataLogStarted && (globalSettings.ReplayLog || globalSettings.GPS_Track_Enabled) { // case 1: sqlite logging isn't running, and we want to start it
 			log.Printf("datalog.go: Watchdog wants to START logging.\n")
 			go dataLog()
-		} else if dataLogStarted && !globalSettings.ReplayLog { // case 2:  sqlite logging is running, and we want to shut it down
+		} else if dataLogStarted && (!globalSettings.ReplayLog && !globalSettings.GPS_Track_Enabled) { // case 2:  sqlite logging is running, and we want to shut it down
 			log.Printf("datalog.go: Watchdog wants to STOP logging.\n")
 			closeDataLog()
 		}

--- a/main/export_datalog.go
+++ b/main/export_datalog.go
@@ -279,7 +279,7 @@ func build_tower_folder(db *sql.DB) (tower_folder *kml.CompoundElement){
 		if scan_err != nil {
 			log.Fatal(fmt.Sprintf("func build_tower_folder row Error: %v", scan_err))
 		}
-		var LatLongRegex = regexp.MustCompile(`(\-?\d+\.?\d+),\s*(\-?\d+\.?\d+)`)
+		var LatLongRegex = regexp.MustCompile(`(-?\d+\.?\d+),\s*(-?\d+\.?\d+)`)
 		LatLongArray := LatLongRegex.FindAllStringSubmatch(tower.TowerID,-1)
 		if s, err := strconv.ParseFloat(LatLongArray[0][1], 64); err == nil {
 			tower.Lat = s
@@ -331,6 +331,7 @@ func build_web_download(filter string) (kml_content *kml.CompoundElement){
 			kml_content.Add(build_tower_folder(db))
 		case "altitude":
 			kml_content = AltitudeDocument(traffic_maps)
+			kml_content.Add(build_tower_folder(db))
 	}
 	return kml.GxKML().Add(kml_content)
 }

--- a/main/export_datalog.go
+++ b/main/export_datalog.go
@@ -29,11 +29,9 @@ type traffic_map struct {
 type traffic_maps map[string]*traffic_map
 
 const (
-	dataLogFile         = "/var/log/stratux.sqlite"
 	gpsLogPath          = "/var/log/"
 	StratuxTimeFormat   = "2006-01-02 15:04:05 -0700 MST"
 	FeetToMeter         = 3.28084
-	TARGET_TYPE_ADSB    = 1
 	TARGET_TYPE_OWNSHIP = 5
 )
 

--- a/main/export_datalog.go
+++ b/main/export_datalog.go
@@ -32,6 +32,7 @@ const (
 	gpsLogPath          = "/var/log/"
 	StratuxTimeFormat   = "2006-01-02 15:04:05 -0700 MST"
 	FeetToMeter         = 3.28084
+	MetersInNM 	    = 1852
 	TARGET_TYPE_OWNSHIP = 5
 )
 
@@ -262,7 +263,7 @@ func build_query(query_type string) string {
 	case "traffic":
 		return fmt.Sprintf("select traffic.Reg, traffic.Tail, traffic.Icao_addr, traffic.TargetType, traffic.Lng, traffic.Lat, "+
 			"traffic.Alt/%v, timestamp.GPSClock_value FROM traffic "+
-			"INNER JOIN timestamp ON traffic.timestamp_id=timestamp.id", FeetToMeter)
+			"INNER JOIN timestamp ON traffic.timestamp_id=timestamp.id WHERE traffic.Distance/%v < 1000", FeetToMeter, MetersInNM)
 	}
 	return "select Lng, Lat, Alt from mySituation"
 }

--- a/main/export_datalog.go
+++ b/main/export_datalog.go
@@ -74,6 +74,8 @@ func defaultKMLPlacemark(details *traffic_map) (placemark *kml.CompoundElement) 
 		kml.Description(description_html),
 		kml.Style("randrom",
 			kml.LineStyle(random_color, kml.Width(10)), kml.PolyStyle(random_color)),
+			kml.IconStyle(kml.Icon(kml.Href("http://maps.google.com/mapfiles/kml/shapes/airports.png"),
+			kml.Scale(0.5),)),
 	)
 	return placemark
 }

--- a/main/export_datalog.go
+++ b/main/export_datalog.go
@@ -1,0 +1,169 @@
+package main
+
+//usage examples
+//export_datalog > multi.kml
+//export_datalog -target=ownship > myflight.kml
+
+import (
+	"database/sql"
+	_ "github.com/mattn/go-sqlite3"
+	"log"
+	"os"
+	"github.com/twpayne/go-kml"
+	"image/color"
+	"fmt"
+	"flag"
+)
+
+type traffic struct {
+	reg string
+	tail string
+}
+
+var dataLogFilef string
+
+const (
+	dataLogFile    = "/var/log/stratux.sqlite"
+)
+
+func writeKML(coordinates []kml.Coordinate) {
+	k := kml.KML(
+		kml.Placemark(
+			kml.Name("OwnShip"),
+			kml.Description("GPS data from Stratux Replaylog database mySituation Table"),
+			kml.Style("ownShip",
+				kml.LineStyle(kml.Color(color.White)),
+			),
+			kml.LineString(
+				kml.AltitudeMode("absolute"),
+				kml.Extrude(true),
+				kml.Tessellate(true),
+				kml.Coordinates(coordinates ...),
+			),
+		),
+	)
+	if err := k.WriteIndent(os.Stdout, "", "  "); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func writeKML_multi(coordinates_slice [][]kml.Coordinate) {
+	k := kml.KML()
+	d := kml.Document()
+	for _, coordinates := range coordinates_slice {
+		d.Add(kml.Placemark(
+				kml.LineString(
+					kml.AltitudeMode("absolute"),
+					kml.Extrude(true),
+					kml.Tessellate(true),
+					kml.Coordinates(coordinates ...),
+
+				),
+			))
+	}
+	k.Add(d)
+	if err := k.WriteIndent(os.Stdout, "", "  "); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func dataLogReader(db *sql.DB, query string)(rows *sql.Rows){
+	rows, err := db.Query(query)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return rows
+
+}
+
+func readCoordinates(db *sql.DB, query string) (coordinates []kml.Coordinate){
+	rows := dataLogReader(db, query)
+	defer rows.Close()
+	//Coords structure https://play.golang.org/p/RLergI3WyN
+	for rows.Next() {
+		var lat, lng, alt float64
+		rows.Scan( &lng, &lat, &alt)
+		coordinates = append(coordinates, kml.Coordinate{lng,lat,alt/3.28084})
+	}
+	return coordinates
+
+}
+
+func get_traffic_list(db *sql.DB, query string) (traffic_list []traffic){
+	rows := dataLogReader(db, query)
+	defer rows.Close()
+	//Coords structure https://play.golang.org/p/RLergI3WyN
+	for rows.Next() {
+		var Reg, Tail string
+		rows.Scan( &Reg, &Tail)
+		traffic_list = append(traffic_list, traffic{Reg, Tail})
+	}
+	return traffic_list
+
+}
+
+func build_traffic_coords(db *sql.DB, traffic_list []traffic) (coordinate_list [][]kml.Coordinate) {
+	for _, traffic := range traffic_list {
+		rows := dataLogReader(db, build_query("traffic", traffic.reg))
+		defer rows.Close()
+		coordinates := []kml.Coordinate{}
+		for rows.Next() {
+			var lat, lng, alt float64
+			rows.Scan(&lng, &lat, &alt)
+			coordinates = append(coordinates, kml.Coordinate{lng, lat, alt / 3.28084})
+		}
+		coordinate_list = append(coordinate_list,coordinates)
+	}
+	return coordinate_list
+}
+
+func build_query(target_type, target_id string)(string){
+	switch {
+	    case "ownship" == target_type:
+		return "select Lng, Lat, Alt from mySituation"
+	    case "traffic" == target_type:
+		return fmt.Sprintf("select Lng, Lat, Alt FROM traffic WHERE Reg = '%s' OR Tail = '%s'", target_id, target_id)
+	    case "traffic_list" == target_type:
+		return "select DISTINCT  Reg, Tail FROM traffic"
+	    case "towers" == target_type:
+		return "select Lng, Lat, Alt FROM traffic WHERE Reg = 'N746FD'"
+	    }
+	return "select Lng, Lat, Alt from mySituation"
+}
+
+func main() {
+	targetPTR := flag.String("target", "", "ownship, traffic, traffic_list, towers")
+	target_idPTR := flag.String("id", "", "a string containing Reg number")
+	flag.Parse()
+	dataLogFilef = dataLogFile
+
+	if _, err := os.Stat(dataLogFilef); os.IsNotExist(err) {
+		log.Printf("No database exists at '%s', record a replay log first.\n", dataLogFilef)
+	}
+	db, err := sql.Open("sqlite3", dataLogFilef)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	//db.Exec("create virtual table repo using github(id, full_name, description, html_url)")
+	//[id LastFixSinceMidnightUTC Lat Lng Quality HeightAboveEllipsoid GeoidSep Satellites
+	// SatellitesTracked SatellitesSeen Accuracy NACp Alt AccuracyVert GPSVertVel
+	// LastFixLocalTime TrueCourse GroundSpeed LastGroundTrackTime GPSTime LastGPSTimeTime
+	// LastValidNMEAMessageTime LastValidNMEAMessage Temp Pressure_alt
+	// LastTempPressTime Pitch Roll Gyro_heading LastAttitudeTime timestamp_id]
+	query := build_query(*targetPTR, *target_idPTR)
+	if *targetPTR != "traffic_list" && *targetPTR !="" {
+		coordinates := readCoordinates(db, query)
+		writeKML(coordinates)
+	}
+	if *targetPTR == "traffic_list" {
+		fmt.Printf("%s", get_traffic_list(db, query))
+	}
+	if *targetPTR == "" && *targetPTR =="" {
+		ownship_coords := readCoordinates(db, build_query("ownship", ""))
+		traffic_coords := build_traffic_coords(db, get_traffic_list(db, build_query("traffic_list", "")))
+		traffic_coords = append(traffic_coords, ownship_coords)
+		writeKML_multi(traffic_coords)
+	}
+}

--- a/main/export_datalog.go
+++ b/main/export_datalog.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"database/sql"
-	"flag"
 	"fmt"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/twpayne/go-kml"
@@ -12,7 +11,6 @@ import (
 	"log"
 	"math/rand"
 	"os"
-	"runtime/pprof"
 	"time"
 )
 
@@ -265,7 +263,7 @@ func build_query(query_type string) string {
 	return "select Lng, Lat, Alt from mySituation"
 }
 
-func build_web_download() (kml_string string){
+func build_web_download() (Time_content *kml.CompoundElement){
 	if _, err := os.Stat(dataLogFile); os.IsNotExist(err) {
 		log.Fatal(fmt.Sprintf("No database exists at '%s', record a replay log first.\n", dataLogFile))
 	}
@@ -277,24 +275,11 @@ func build_web_download() (kml_string string){
 	ownship_maps := build_traffic_maps(db, "ownship")     //ownship traffic map
 	traffic_maps := build_traffic_maps(db, "all_traffic") //all other traffic map
 	traffic_maps["ownship"] = ownship_maps["ownship"]     //combine both ownship and other traffic
-	Time_content := TimeKML(traffic_maps)                 //Filter based on GPS Time of target
-	buf := new(bytes.Buffer)
-	kml_string = Time_content.WriteIndent(buf, "", "  ")
-	return kml_string
+	Time_content = TimeKML(traffic_maps)                 //Filter based on GPS Time of target
+	return Time_content
 }
 
-func main() {
-	var cpuprofile = flag.String("cpuprofile", "", "write cpu profile to file")
-	flag.Parse()
-	if *cpuprofile != "" {
-		f, err := os.Create(*cpuprofile)
-		if err != nil {
-			log.Fatal(err)
-		}
-		pprof.StartCPUProfile(f)
-		defer pprof.StopCPUProfile()
-	}
-
+/*func main() {
 	if _, err := os.Stat(dataLogFile); os.IsNotExist(err) {
 		log.Fatal(fmt.Sprintf("No database exists at '%s', record a replay log first.\n", dataLogFile))
 	}
@@ -310,4 +295,5 @@ func main() {
 	writeFile("time", Time_content)
 	Alt_content := AltKML(traffic_maps)                   //Filter based on Minimum Altitude
 	writeFile("alt", Alt_content)
-}
+	fmt.Print(build_web_download())
+}*/

--- a/main/export_datalog.go
+++ b/main/export_datalog.go
@@ -142,15 +142,23 @@ func build_traffic_coords(db *sql.DB, traffic_list []string) (data []traffic_pos
 		rows := dataLogReader(db, build_query("traffic", traffic))
 		defer rows.Close()
 		coordinates := []kml.Coordinate{}
-		var tail, reg string
+		var tail, reg, fancy_name string
 		var targettype int
+		var fancy_name_found bool
 		for rows.Next() {
 			var lat, lng, alt float64
-
 			rows.Scan(&reg, &tail, &targettype, &lng, &lat, &alt)
+			if !fancy_name_found && tail != reg{
+				fancy_name = tail
+				fancy_name_found = true
+			}
 			coordinates = append(coordinates, kml.Coordinate{lng, lat, alt / 3.28084})
 		}
-		data = append(data, traffic_position{reg: reg, tail: tail, targettype: targettype, coordinates: coordinates})
+		if fancy_name_found{
+			data = append(data, traffic_position{reg: reg, tail: fancy_name, targettype: targettype, coordinates: coordinates})
+		} else {
+			data = append(data, traffic_position{reg: reg, tail: tail, targettype: targettype, coordinates: coordinates})
+		}
 	}
 	return data
 }

--- a/main/export_datalog.go
+++ b/main/export_datalog.go
@@ -220,7 +220,7 @@ func build_traffic_maps(db *sql.DB, traffic_type string) (maps traffic_maps) {
 		}
 		if _, missing := maps[traffic_row.reg]; !missing {
 			//Create maps["N123AB"] with reg, tail, target_type and minimum_altitude. minimum_altitude is set
-			// since the default initialization value is 0 and make clean logic difficult
+			// since the default initialization value is 0 and makes clean logic difficult
 			maps[traffic_row.reg] = &traffic_map{reg: traffic_row.reg, tail: traffic_row.tail,
 				target_type: traffic_row.target_type, target_type_string: target_type_reverse_slice[traffic_row.target_type],
 				minimum_altitude: alt}
@@ -238,7 +238,7 @@ func build_traffic_maps(db *sql.DB, traffic_type string) (maps traffic_maps) {
 		if err != nil {
 			log.Fatal(fmt.Sprintf("%s - %s: %s \n%s\n", traffic_row.reg, traffic_row.tail, GPSClock_value, err))
 		}
-		if time_obj.Year() < 1987 {
+		if time_obj.Year() == 0001 {
 			//If time is not valid skip writing coordinates and time
 			continue
 		}
@@ -258,8 +258,6 @@ func build_query(query_type string) string {
 		return fmt.Sprintf("select traffic.Reg, traffic.Tail, traffic.Icao_addr, traffic.TargetType, traffic.Lng, traffic.Lat, "+
 			"traffic.Alt/%v, timestamp.GPSClock_value FROM traffic "+
 			"INNER JOIN timestamp ON traffic.timestamp_id=timestamp.id", FeetToMeter)
-	case "towers":
-		return "select Lng, Lat, Alt FROM traffic WHERE Reg = 'N746FD'"
 	}
 	return "select Lng, Lat, Alt from mySituation"
 }
@@ -289,22 +287,3 @@ func build_web_download(filter string) (kml_content *kml.CompoundElement){
 	}
 	return kml_content
 }
-
-/*func main() {
-	if _, err := os.Stat(dataLogFile); os.IsNotExist(err) {
-		log.Fatal(fmt.Sprintf("No database exists at '%s', record a replay log first.\n", dataLogFile))
-	}
-	db, err := sql.Open("sqlite3", dataLogFile)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer db.Close()
-	ownship_maps := build_traffic_maps(db, "ownship")     //ownship traffic map
-	traffic_maps := build_traffic_maps(db, "all_traffic") //all other traffic map
-	traffic_maps["ownship"] = ownship_maps["ownship"]     //combine both ownship and other traffic
-	Time_content := TimeKML(traffic_maps)                 //Filter based on GPS Time of target
-	writeFile("time", Time_content)
-	Alt_content := AltKML(traffic_maps)                   //Filter based on Minimum Altitude
-	writeFile("alt", Alt_content)
-	fmt.Print(build_web_download())
-}*/

--- a/main/export_datalog.go
+++ b/main/export_datalog.go
@@ -73,9 +73,10 @@ func defaultKMLPlacemark(details *traffic_map) (placemark *kml.CompoundElement) 
 		kml.Name(fmt.Sprintf("%s - %s", details.tail, details.reg)),
 		kml.Description(description_html),
 		kml.Style("randrom",
-			kml.LineStyle(random_color, kml.Width(10)), kml.PolyStyle(random_color)),
+			kml.LineStyle(random_color, kml.Width(10)), kml.PolyStyle(random_color),
 			kml.IconStyle(kml.Icon(kml.Href("http://maps.google.com/mapfiles/kml/shapes/airports.png"),
-			kml.Scale(0.5),)),
+				kml.Scale(0.5))),
+		),
 	)
 	return placemark
 }

--- a/main/export_datalog.go
+++ b/main/export_datalog.go
@@ -13,6 +13,8 @@ import (
 	"image/color"
 	"fmt"
 	"flag"
+	"io/ioutil"
+	"bytes"
 )
 
 
@@ -28,7 +30,21 @@ var dataLogFilef string
 
 const (
 	dataLogFile    = "/var/log/stratux.sqlite"
+	gpsLogPath     = "/var/log/"
 )
+
+func check(e error) {
+    if e != nil {
+        panic(e)
+    }
+}
+
+func writeFile(name string, content *kml.CompoundElement){
+	buf := new(bytes.Buffer)
+	content.WriteIndent(buf, "", "  ")
+	err := ioutil.WriteFile(fmt.Sprintf("%s%s.kml", gpsLogPath, name), buf.Bytes(), 0644)
+    	check(err)
+}
 
 func writeKML(coordinates []kml.Coordinate) {
 	k := kml.KML(
@@ -97,9 +113,7 @@ func writeKML_multi(traffic_data []traffic_position) {
 			))
 	}
 	k.Add(d)
-	if err := k.WriteIndent(os.Stdout, "", "  "); err != nil {
-		log.Fatal(err)
-	}
+	writeFile("multi", k)
 }
 
 func dataLogReader(db *sql.DB, query string)(rows *sql.Rows){

--- a/main/export_datalog.go
+++ b/main/export_datalog.go
@@ -17,26 +17,26 @@ import (
 )
 
 type traffic_map struct {
-	reg              string
-	tail             string
-	target_type      int
-	target_type_string      string
-	icao_address     uint32
-	coordinates      []kml.Coordinate
-	times            []time.Time
-	minimum_altitude float64
-	maximum_altitude float64
+	reg                string
+	tail               string
+	target_type        int
+	target_type_string string
+	icao_address       uint32
+	coordinates        []kml.Coordinate
+	times              []time.Time
+	minimum_altitude   float64
+	maximum_altitude   float64
 }
 
 type traffic_maps map[string]*traffic_map
 
 const (
-	dataLogFile       = "/var/log/stratux.sqlite"
-	gpsLogPath        = "/var/log/"
-	StratuxTimeFormat = "2006-01-02 15:04:05 -0700 MST"
-	FeetToMeter = 3.28084
-	TARGET_TYPE_ADSB      = 1
-	TARGET_TYPE_OWNSHIP   = 5
+	dataLogFile         = "/var/log/stratux.sqlite"
+	gpsLogPath          = "/var/log/"
+	StratuxTimeFormat   = "2006-01-02 15:04:05 -0700 MST"
+	FeetToMeter         = 3.28084
+	TARGET_TYPE_ADSB    = 1
+	TARGET_TYPE_OWNSHIP = 5
 )
 
 var target_type_reverse_slice = []string{"Mode S", "ADS-B 1090 MHz", "ADS-R 978 MHz", "TIS-B S 978 MHz", "TIS-B 978 MHz", "Ownship"}
@@ -67,12 +67,12 @@ func defaultKMLDocument() (document *kml.CompoundElement) {
 func defaultKMLPlacemark(details *traffic_map) (placemark *kml.CompoundElement) {
 	var random_color = kml.Color(color.RGBA{uint8(rand.Intn(255)), uint8(rand.Intn(255)),
 		uint8(rand.Intn(255)), uint8(255)})
-	description_html := fmt.Sprintf("Tail: <a href='https://flightaware.com/live/flight/%[1]s'>%[1]s</a> <br>" +
-		"Registration: <a href='https://flightaware.com/live/flight/%[2]s'>%[2]s</a><br>" +
-		"Type: %[3]s <br>" +
-		"Minumun Altitude: %[4]v ft<br>" +
+	description_html := fmt.Sprintf("Tail: <a href='https://flightaware.com/live/flight/%[1]s'>%[1]s</a> <br>"+
+		"Registration: <a href='https://flightaware.com/live/flight/%[2]s'>%[2]s</a><br>"+
+		"Type: %[3]s <br>"+
+		"Minumun Altitude: %[4]v ft<br>"+
 		"Maximum Altitude: %[5]v ft<br>",
-		details.tail, details.reg, details.target_type_string,details.minimum_altitude*FeetToMeter,details.maximum_altitude*FeetToMeter)
+		details.tail, details.reg, details.target_type_string, details.minimum_altitude*FeetToMeter, details.maximum_altitude*FeetToMeter)
 	placemark = kml.Placemark(
 		kml.Name(fmt.Sprintf("%s - %s", details.tail, details.reg)),
 		kml.Description(description_html),
@@ -104,9 +104,9 @@ func addToTypeFolder(input_folders map[string]*kml.CompoundElement, traffic_pos 
 	case TARGET_TYPE_OWNSHIP:
 		folders["ownship"].Add(placemark)
 	case TARGET_TYPE_ADSB:
-		if traffic_pos.minimum_altitude > 5500{
+		if traffic_pos.minimum_altitude > 5500 {
 			folders["ADSBhigh"].Add(placemark)
-		}else {
+		} else {
 			folders["ADSBlow"].Add(placemark)
 		}
 	default:
@@ -253,11 +253,11 @@ func build_query(query_type string) string {
 
 	switch query_type {
 	case "ownship":
-		return fmt.Sprintf("select mySituation.Lng, mySituation.Lat, mySituation.Alt/%v, timestamp.GPSClock_value " +
+		return fmt.Sprintf("select mySituation.Lng, mySituation.Lat, mySituation.Alt/%v, timestamp.GPSClock_value "+
 			"from mySituation INNER JOIN timestamp ON mySituation.timestamp_id=timestamp.id", FeetToMeter)
 	case "traffic":
-		return fmt.Sprintf("select traffic.Reg, traffic.Tail, traffic.Icao_addr, traffic.TargetType, traffic.Lng, traffic.Lat, " +
-			"traffic.Alt/%v, timestamp.GPSClock_value FROM traffic " +
+		return fmt.Sprintf("select traffic.Reg, traffic.Tail, traffic.Icao_addr, traffic.TargetType, traffic.Lng, traffic.Lat, "+
+			"traffic.Alt/%v, timestamp.GPSClock_value FROM traffic "+
 			"INNER JOIN timestamp ON traffic.timestamp_id=timestamp.id", FeetToMeter)
 	case "towers":
 		return "select Lng, Lat, Alt FROM traffic WHERE Reg = 'N746FD'"

--- a/main/export_datalog.go
+++ b/main/export_datalog.go
@@ -199,6 +199,11 @@ func build_traffic_maps(db *sql.DB, traffic_type string) (maps traffic_maps) {
 		if scan_err != nil && traffic_type == "ownship" {
 			rows.Scan(&lng, &lat, &alt, &GPSClock_value)
 		}
+		if lat == 0 || lng == 0 {
+			//Skip traffic with no valid GPS coordinates. These values occur in mySituation where there is no valid GPS fix
+			//FIXME: cleaner way to access state of GPS fix?
+			continue
+		}
 		if traffic_row.tail == "" || traffic_row.reg == "" {
 			//Give UAT or malformed ADSB traffic clean names using ICAO string
 			string_icao := fmt.Sprint(traffic_row.icao_address)

--- a/main/export_datalog.go
+++ b/main/export_datalog.go
@@ -261,7 +261,7 @@ func build_query(query_type string) string {
 	return "select Lng, Lat, Alt from mySituation"
 }
 
-func build_web_download() (Time_content *kml.CompoundElement){
+func build_web_download(filter string) (kml_content *kml.CompoundElement){
 	if _, err := os.Stat(dataLogFile); os.IsNotExist(err) {
 		log.Fatal(fmt.Sprintf("No database exists at '%s', record a replay log first.\n", dataLogFile))
 	}
@@ -273,8 +273,13 @@ func build_web_download() (Time_content *kml.CompoundElement){
 	ownship_maps := build_traffic_maps(db, "ownship")     //ownship traffic map
 	traffic_maps := build_traffic_maps(db, "all_traffic") //all other traffic map
 	traffic_maps["ownship"] = ownship_maps["ownship"]     //combine both ownship and other traffic
-	Time_content = TimeKML(traffic_maps)                 //Filter based on GPS Time of target
-	return Time_content
+	switch filter {
+		case "time":
+			kml_content = TimeKML(traffic_maps)   //Filter based on GPS Time of target
+		case "altitude":
+			kml_content = AltKML(traffic_maps)
+	}
+	return kml_content
 }
 
 /*func main() {

--- a/main/export_datalog.go
+++ b/main/export_datalog.go
@@ -274,9 +274,14 @@ func build_web_download(filter string) (kml_content *kml.CompoundElement){
 	}
 	defer db.Close()
 	ownship_maps := build_traffic_maps(db, "ownship")     //ownship traffic map
-	traffic_maps := build_traffic_maps(db, "all_traffic") //all other traffic map
-	traffic_maps["ownship"] = ownship_maps["ownship"]     //combine both ownship and other traffic
+	var traffic_maps traffic_maps
+	if filter != "ownship"{
+		traffic_maps = build_traffic_maps(db, "all_traffic") //all other traffic map
+		traffic_maps["ownship"] = ownship_maps["ownship"]     //combine both ownship and other traffic
+		}
 	switch filter {
+		case "ownship":
+			kml_content = TimeKML(ownship_maps)
 		case "time":
 			kml_content = TimeKML(traffic_maps)   //Filter based on GPS Time of target
 		case "altitude":

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1019,7 +1019,7 @@ func defaultSettings() {
 	globalSettings.DEBUG = false
 	globalSettings.DisplayTrafficSource = false
 	globalSettings.ReplayLog = false //TODO: 'true' for debug builds.
-	globalSettings.OwnshipModeS = "F00007"
+	globalSettings.OwnshipModeS = "F00000"
 	globalSettings.GPS_Track_Format = "KML"
 	globalSettings.GPS_Track_Enabled = false
 }

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -957,6 +957,8 @@ type settings struct {
 	PPM                  int
 	OwnshipModeS         string
 	WatchList            string
+	GPS_Track_Format     string
+	GPS_Track_Enabled    bool
 }
 
 type status struct {
@@ -1007,7 +1009,9 @@ func defaultSettings() {
 	globalSettings.DEBUG = false
 	globalSettings.DisplayTrafficSource = false
 	globalSettings.ReplayLog = false //TODO: 'true' for debug builds.
-	globalSettings.OwnshipModeS = "F00000"
+	globalSettings.OwnshipModeS = "F00007"
+	globalSettings.GPS_Track_Format = "KML"
+	globalSettings.GPS_Track_Enabled = false
 }
 
 func readSettings() {

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -377,6 +377,13 @@ func handleAltitudeKML(w http.ResponseWriter, r *http.Request) {
 	kml_content.WriteIndent(w,  "", "  ")
 }
 
+func handleOwnshipKML(w http.ResponseWriter, r *http.Request) {
+	setNoCache(w)
+	setXMLHeaders(w)
+	kml_content := build_web_download("ownship")
+	kml_content.WriteIndent(w,  "", "  ")
+}
+
 // https://gist.github.com/alexisrobert/982674.
 // Copyright (c) 2010-2014 Alexis ROBERT <alexis.robert@gmail.com>.
 const dirlisting_tpl = `<?xml version="1.0" encoding="iso-8859-1"?>
@@ -510,6 +517,7 @@ func managementInterface() {
 	http.HandleFunc("/roPartitionRebuild", handleroPartitionRebuild)
 	http.HandleFunc("/getTimeKML", handleTimeKML)
 	http.HandleFunc("/getAltitudeKML", handleAltitudeKML)
+	http.HandleFunc("/getOwnshipKML", handleOwnshipKML)
 
 	err := http.ListenAndServe(managementAddr, nil)
 

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -248,6 +248,10 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 							continue
 						}
 						globalSettings.OwnshipModeS = fmt.Sprintf("%02X%02X%02X", hexn[0], hexn[1], hexn[2])
+					case "GPS_Track_Format":
+						globalSettings.GPS_Track_Format = val.(string)
+					case "GPS_Track_Enabled":
+						globalSettings.GPS_Track_Enabled = val.(bool)
 					default:
 						log.Printf("handleSettingsSetRequest:json: unrecognized key:%s\n", key)
 					}

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -356,6 +356,12 @@ func handleroPartitionRebuild(w http.ResponseWriter, r *http.Request) {
 	addSystemError(ret_err)
 }
 
+func handleTimeKML(w http.ResponseWriter, r *http.Request) {
+	setNoCache(w)
+	clientsJSON := build_web_download()
+	fmt.Fprintf(w, "%s\n", clientsJSON)
+}
+
 // https://gist.github.com/alexisrobert/982674.
 // Copyright (c) 2010-2014 Alexis ROBERT <alexis.robert@gmail.com>.
 const dirlisting_tpl = `<?xml version="1.0" encoding="iso-8859-1"?>
@@ -487,6 +493,7 @@ func managementInterface() {
 	http.HandleFunc("/getClients", handleClientsGetRequest)
 	http.HandleFunc("/updateUpload", handleUpdatePostRequest)
 	http.HandleFunc("/roPartitionRebuild", handleroPartitionRebuild)
+	http.HandleFunc("/getTimeKML", handleTimeKML)
 
 	err := http.ListenAndServe(managementAddr, nil)
 

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -25,7 +25,6 @@ import (
 	"syscall"
 	"text/template"
 	"time"
-	"github.com/twpayne/go-kml"
 )
 
 type SettingMessage struct {
@@ -338,6 +337,11 @@ func setJSONHeaders(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
 }
 
+func setXMLHeaders(w http.ResponseWriter) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Content-Type", "application/xml")
+}
+
 func defaultServer(w http.ResponseWriter, r *http.Request) {
 	//	setNoCache(w)
 
@@ -359,8 +363,16 @@ func handleroPartitionRebuild(w http.ResponseWriter, r *http.Request) {
 
 func handleTimeKML(w http.ResponseWriter, r *http.Request) {
 	setNoCache(w)
-	kml_conent := build_web_download()
-	kml_conent.WriteIndent(w,  "", "  ")
+	setXMLHeaders(w)
+	kml_content := build_web_download("time")
+	kml_content.WriteIndent(w,  "", "  ")
+}
+
+func handleAltitudeKML(w http.ResponseWriter, r *http.Request) {
+	setNoCache(w)
+	setXMLHeaders(w)
+	kml_content := build_web_download("altitude")
+	kml_content.WriteIndent(w,  "", "  ")
 }
 
 // https://gist.github.com/alexisrobert/982674.
@@ -495,6 +507,7 @@ func managementInterface() {
 	http.HandleFunc("/updateUpload", handleUpdatePostRequest)
 	http.HandleFunc("/roPartitionRebuild", handleroPartitionRebuild)
 	http.HandleFunc("/getTimeKML", handleTimeKML)
+	http.HandleFunc("/getAltitudeKML", handleAltitudeKML)
 
 	err := http.ListenAndServe(managementAddr, nil)
 

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -25,6 +25,7 @@ import (
 	"syscall"
 	"text/template"
 	"time"
+	"github.com/twpayne/go-kml"
 )
 
 type SettingMessage struct {
@@ -358,8 +359,8 @@ func handleroPartitionRebuild(w http.ResponseWriter, r *http.Request) {
 
 func handleTimeKML(w http.ResponseWriter, r *http.Request) {
 	setNoCache(w)
-	clientsJSON := build_web_download()
-	fmt.Fprintf(w, "%s\n", clientsJSON)
+	kml_conent := build_web_download()
+	kml_conent.WriteIndent(w,  "", "  ")
 }
 
 // https://gist.github.com/alexisrobert/982674.

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -14,6 +14,7 @@ var URL_REBOOT			= "http://" + URL_HOST_BASE + "/reboot";
 var URL_SHUTDOWN		= "http://" + URL_HOST_BASE + "/shutdown";
 var URL_KML_TIME        = "http://"	+ URL_HOST_BASE + "/getTimeKML"
 var URL_KML_Altitude    = "http://"	+ URL_HOST_BASE + "/getAltitudeKML"
+var URL_KML_Altitude    = "http://"	+ URL_HOST_BASE + "/getOwnshipKML"
 
 // define the module with dependency on mobile-angular-ui
 //var app = angular.module('stratux', ['ngRoute', 'mobile-angular-ui', 'mobile-angular-ui.gestures', 'appControllers']);

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -14,7 +14,7 @@ var URL_REBOOT			= "http://" + URL_HOST_BASE + "/reboot";
 var URL_SHUTDOWN		= "http://" + URL_HOST_BASE + "/shutdown";
 var URL_KML_TIME        = "http://"	+ URL_HOST_BASE + "/getTimeKML"
 var URL_KML_Altitude    = "http://"	+ URL_HOST_BASE + "/getAltitudeKML"
-var URL_KML_Altitude    = "http://"	+ URL_HOST_BASE + "/getOwnshipKML"
+var URL_KML_Ownship     = "http://"	+ URL_HOST_BASE + "/getOwnshipKML"
 
 // define the module with dependency on mobile-angular-ui
 //var app = angular.module('stratux', ['ngRoute', 'mobile-angular-ui', 'mobile-angular-ui.gestures', 'appControllers']);

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -12,6 +12,8 @@ var URL_WEATHER_WS 		= "ws://"	+ URL_HOST_BASE + "/weather";
 var URL_UPDATE_UPLOAD	= "http://" + URL_HOST_BASE + "/updateUpload";
 var URL_REBOOT			= "http://" + URL_HOST_BASE + "/reboot";
 var URL_SHUTDOWN		= "http://" + URL_HOST_BASE + "/shutdown";
+var URL_KML_TIME        = "http://"	+ URL_HOST_BASE + "/getTimeKML"
+var URL_KML_Altitude    = "http://"	+ URL_HOST_BASE + "/getAltitudeKML"
 
 // define the module with dependency on mobile-angular-ui
 //var app = angular.module('stratux', ['ngRoute', 'mobile-angular-ui', 'mobile-angular-ui.gestures', 'appControllers']);

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -153,6 +153,17 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 			$scope.Ui.turnOff('modalKML');
         })
 	};
+	$scope.downloadOwnshipKML = function () {
+		$scope.download = true;
+		$http.get(URL_KML_Altitude).then(function(response){
+            var blob = new Blob([ response.data ], { type : 'application/xml' });
+			var downloadLink = angular.element('<a></a>');
+			downloadLink.attr('href',window.URL.createObjectURL(blob));
+			downloadLink.attr('download', 'Ownship.kml');
+			downloadLink[0].click();
+			$scope.download = false;
+        })
+	};
 
 	$scope.postShutdown = function () {
 		$window.location.href = "/";

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -166,7 +166,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 	};
 	$scope.downloadOwnshipKML = function () {
 		$scope.ownshipdownload = true;
-		$http.get(URL_KML_Altitude).then(function(response){
+		$http.get(URL_KML_Ownship).then(function(response){
             var blob = new Blob([ response.data ], { type : 'application/xml' });
 			var downloadLink = angular.element('<a></a>');
 			downloadLink.attr('href',window.URL.createObjectURL(blob));

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -142,6 +142,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
         },function(response){
         	alert("Error: Ensure a /var/log/stratux.sqlite file exists by recording a replay log or enabling GPS logging.\n" +
 				"check /var/log/stratux.log for more details")
+			$scope.download = false;
 		})
 	};
 	$scope.downloadAltitudeKML = function () {
@@ -157,6 +158,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
         },function(response){
         	alert("Error: Ensure a /var/log/stratux.sqlite file exists by recording a replay log or enabling GPS logging.\n" +
 				"check /var/log/stratux.log for more details")
+			$scope.download = false;
 		})
 	};
 	$scope.downloadOwnshipKML = function () {
@@ -171,6 +173,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
         },function(response){
         	alert("Error: Ensure a /var/log/stratux.sqlite file exists by recording a replay log or enabling GPS logging.\n" +
 				"check /var/log/stratux.log for more details")
+			$scope.download = false;
 		})
 	};
 

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -6,7 +6,8 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 
 	$scope.$parent.helppage = 'plates/settings-help.html';
 
-	var toggles = ['UAT_Enabled', 'ES_Enabled', 'GPS_Enabled', 'AHRS_Enabled', 'DisplayTrafficSource', 'DEBUG', 'ReplayLog']; 
+	var toggles = ['UAT_Enabled', 'ES_Enabled', 'GPS_Enabled', 'AHRS_Enabled', 'DisplayTrafficSource', 'DEBUG', 'ReplayLog', 'GPS_Track_Enabled'];
+	$scope.format_options = ['KML', 'GPX'];
 	var settings = {};
 	for (i = 0; i < toggles.length; i++) {
 		settings[toggles[i]] = undefined;
@@ -27,6 +28,8 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		$scope.PPM = settings.PPM;
 		$scope.WatchList = settings.WatchList;
 		$scope.OwnshipModeS = settings.OwnshipModeS;
+		$scope.GPS_Track_Format = settings.GPS_Track_Format;
+		$scope.GPS_Track_Enabled = settings.GPS_Track_Enabled;
 	}
 
 	function getSettings() {
@@ -108,6 +111,16 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 			settings["OwnshipModeS"] = $scope.OwnshipModeS.toUpperCase();
 			newsettings = {
 				"OwnshipModeS": $scope.OwnshipModeS.toUpperCase()
+			};
+			// console.log(angular.toJson(newsettings));
+			setSettings(angular.toJson(newsettings));
+		}
+	};
+	$scope.updategpsformat = function () {
+		if ($scope.GPS_Track_Format !== settings["GPS_Track_Format"]) {
+			settings["GPS_Track_Format"] = $scope.GPS_Track_Format.toUpperCase();
+			newsettings = {
+				"GPS_Track_Format": $scope.GPS_Track_Format.toUpperCase()
 			};
 			// console.log(angular.toJson(newsettings));
 			setSettings(angular.toJson(newsettings));

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -127,14 +127,31 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		}
 	};
 
+	$scope.download = false;
 	$scope.downloadTimeKML = function () {
-		var content = '<?xml version="1.0" encoding="UTF-8"?>\n<kml xmlns="http://www.opengis.net/kml/2.2"><Placemark><name>Simple placemark</name><description>Attached to the ground. Intelligently places itself at the height of the underlying terrain.</description><Point><coordinates>-122.0822035425683,37.42228990140251</coordinates></Point></Placemark></kml>'
-		var blob = new Blob([ content ], { type : 'text/plain' });
-		var downloadLink = angular.element('<a></a>');
-		downloadLink.attr('href',window.URL.createObjectURL(blob));
-		downloadLink.attr('download', 'time.kml');
-		downloadLink[0].click();
-	}
+		$scope.download = true;
+		$http.get( URL_KML_TIME).then(function(response){
+			var blob = new Blob([ response.data ], { type : 'application/xml' });
+			var downloadLink = angular.element('<a></a>');
+			downloadLink.attr('href',window.URL.createObjectURL(blob));
+			downloadLink.attr('download', 'ReplayLog_time.kml');
+			downloadLink[0].click();
+			$scope.download = false;
+			$scope.Ui.turnOff('modalKML');
+        })
+	};
+	$scope.downloadAltitudeKML = function () {
+		$scope.download = true;
+		$http.get(URL_KML_Altitude).then(function(response){
+            var blob = new Blob([ response.data ], { type : 'application/xml' });
+			var downloadLink = angular.element('<a></a>');
+			downloadLink.attr('href',window.URL.createObjectURL(blob));
+			downloadLink.attr('download', 'ReplayLog_altitude.kml');
+			downloadLink[0].click();
+			$scope.download = false;
+			$scope.Ui.turnOff('modalKML');
+        })
+	};
 
 	$scope.postShutdown = function () {
 		$window.location.href = "/";

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -139,7 +139,10 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 			downloadLink[0].click();
 			$scope.download = false;
 			$scope.Ui.turnOff('modalKML');
-        })
+        },function(response){
+        	alert("Error: Ensure a /var/log/stratux.sqlite file exists by recording a replay log or enabling GPS logging.\n" +
+				"check /var/log/stratux.log for more details")
+		})
 	};
 	$scope.downloadAltitudeKML = function () {
 		$scope.download = true;
@@ -151,7 +154,10 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 			downloadLink[0].click();
 			$scope.download = false;
 			$scope.Ui.turnOff('modalKML');
-        })
+        },function(response){
+        	alert("Error: Ensure a /var/log/stratux.sqlite file exists by recording a replay log or enabling GPS logging.\n" +
+				"check /var/log/stratux.log for more details")
+		})
 	};
 	$scope.downloadOwnshipKML = function () {
 		$scope.download = true;
@@ -162,7 +168,10 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 			downloadLink.attr('download', 'Ownship.kml');
 			downloadLink[0].click();
 			$scope.download = false;
-        })
+        },function(response){
+        	alert("Error: Ensure a /var/log/stratux.sqlite file exists by recording a replay log or enabling GPS logging.\n" +
+				"check /var/log/stratux.log for more details")
+		})
 	};
 
 	$scope.postShutdown = function () {

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -7,7 +7,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 	$scope.$parent.helppage = 'plates/settings-help.html';
 
 	var toggles = ['UAT_Enabled', 'ES_Enabled', 'Ping_Enabled', 'GPS_Enabled', 'AHRS_Enabled', 'DisplayTrafficSource', 'DEBUG', 'ReplayLog', 'GPS_Track_Enabled'];
-	$scope.format_options = ['KML', 'GPX'];
+	$scope.format_options = ['KML'];
 	var settings = {};
 	for (i = 0; i < toggles.length; i++) {
 		settings[toggles[i]] = undefined;

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -127,6 +127,15 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		}
 	};
 
+	$scope.downloadTimeKML = function () {
+		var content = '<?xml version="1.0" encoding="UTF-8"?>\n<kml xmlns="http://www.opengis.net/kml/2.2"><Placemark><name>Simple placemark</name><description>Attached to the ground. Intelligently places itself at the height of the underlying terrain.</description><Point><coordinates>-122.0822035425683,37.42228990140251</coordinates></Point></Placemark></kml>'
+		var blob = new Blob([ content ], { type : 'text/plain' });
+		var downloadLink = angular.element('<a></a>');
+		downloadLink.attr('href',window.URL.createObjectURL(blob));
+		downloadLink.attr('download', 'time.kml');
+		downloadLink[0].click();
+	}
+
 	$scope.postShutdown = function () {
 		$window.location.href = "/";
 		$location.path('/home');

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -129,6 +129,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 	};
 
 	$scope.download = false;
+	$scope.ownshipdownload = false;
 	$scope.downloadTimeKML = function () {
 		$scope.download = true;
 		$http.get( URL_KML_TIME).then(function(response){
@@ -143,6 +144,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
         	alert("Error: Ensure a /var/log/stratux.sqlite file exists by recording a replay log or enabling GPS logging.\n" +
 				"check /var/log/stratux.log for more details")
 			$scope.download = false;
+			$scope.Ui.turnOff('modalKML');
 		})
 	};
 	$scope.downloadAltitudeKML = function () {
@@ -159,21 +161,22 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
         	alert("Error: Ensure a /var/log/stratux.sqlite file exists by recording a replay log or enabling GPS logging.\n" +
 				"check /var/log/stratux.log for more details")
 			$scope.download = false;
+			$scope.Ui.turnOff('modalKML');
 		})
 	};
 	$scope.downloadOwnshipKML = function () {
-		$scope.download = true;
+		$scope.ownshipdownload = true;
 		$http.get(URL_KML_Altitude).then(function(response){
             var blob = new Blob([ response.data ], { type : 'application/xml' });
 			var downloadLink = angular.element('<a></a>');
 			downloadLink.attr('href',window.URL.createObjectURL(blob));
 			downloadLink.attr('download', 'Ownship.kml');
 			downloadLink[0].click();
-			$scope.download = false;
+			$scope.ownshipdownload = false;
         },function(response){
         	alert("Error: Ensure a /var/log/stratux.sqlite file exists by recording a replay log or enabling GPS logging.\n" +
 				"check /var/log/stratux.log for more details")
-			$scope.download = false;
+			$scope.ownshipdownload = false;
 		})
 	};
 

--- a/web/plates/settings-help.html
+++ b/web/plates/settings-help.html
@@ -31,7 +31,7 @@
    <li><strong>Reboot</strong> will immediately reboot the Stratux.  After the reboot you may have to rejoin the WiFi connection to reconnect.</li>
    </ul>
 
-   <p>The <strong>GPS Track File</strong> allows you to save your GPS track to upload to various services like Google Earth or CloudAhoy.
+   <p>The <strong>GPS Track File</strong> allows you to save your GPS track to a file which can be viewed using services like Google Earth or CloudAhoy.
 	   Enabling the <strong>Write GPS to file</strong> will start writing to a database file that can then be downloaded as a KML file by pressing <strong>Get KML</strong>.
 	   To start a new track file SSH into the stratux device and run <code>rm /var/log/stratux.sqlite</code>
    </p>

--- a/web/plates/settings-help.html
+++ b/web/plates/settings-help.html
@@ -29,5 +29,10 @@
    <ul>
    <li><strong>Shutdown</strong> will immediately shutdown the Stratux.  You may then safely remove power.</li>
    <li><strong>Reboot</strong> will immediately reboot the Stratux.  After the reboot you may have to rejoin the WiFi connection to reconnect.</li>
-   </ul>    
+   </ul>
+
+   <p>The <strong>GPS Track File</strong> allows you to save your GPS track to upload to various services like Google Earth or CloudAhoy.
+	   Enabling the <strong>Write GPS to file</strong> will start writing to a database file that can then be downloaded as a KML file by pressing <strong>Get KML</strong>.
+	   To start a new track file SSH into the stratux device and run <code>rm /var/log/stratux.sqlite</code>
+   </p>
 </div>

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -154,7 +154,7 @@
 						</div>
 					</div>
 				</div>
-				<div ng-show="download" class="form-group reset-flow ng-cloak">
+				<div ng-show="ownshipdownload" class="form-group reset-flow ng-cloak">
 					<span  class="fake-btn fake-btn-block">Processing Ownship...</span>
 				</div>
 			</div>

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -50,8 +50,13 @@
 				</div>
 				<div class="form-group">
 					<label class="control-label col-xs-7">Record Replay Logs</label>
-					<div class="col-xs-5">
-						<ui-switch ng-model='ReplayLog' settings-change></ui-switch>
+					<div class="row">
+						<div class="col-xs-2">
+							<ui-switch ng-model='ReplayLog' settings-change></ui-switch>
+						</div>
+						<div class="col-xs-3">
+							<button class="btn btn-primary btn-block" ui-turn-on="modalKML">Get KML</button>
+						</div>
 					</div>
 				</div>
 			</div>
@@ -211,5 +216,31 @@
 	</div>
   </div> 
 
+  <div class="modal" ui-if="modalKML" ui-state="modalKML">
+	<div class="modal-overlay "></div>
+		<div class="vertical-alignment-helper center-block">
+			<div class="modal-dialog vertical-align-center">
+
+	  <div class="modal-content">
+		<div class="modal-header">
+		  <button class="close"
+				  ui-turn-off="modalKML"></button>
+		  <h4 class="modal-title">Download KML</h4>
+		</div>
+		<div class="modal-body">
+		  <p>Do you want to download a KML version of the replay log?</p>
+		  <p>Your two options are you download KML file based on time, or one that allows you filter traffic based on the altitude of the traffic.</p>
+			<div class="separator">
+			<a ng-click="dowloadTimeKML()" ng-href="{{ url }}" ui-turn-off="modalKML" class="btn btn-primary">Time KML</a>
+			<a ng-click="dowloadAltitudeKML()" ng-href="{{ url }}" ui-turn-off="modalKML" class="btn btn-primary">Altitude KML</a>
+			</div>
+		</div>
+		  <div class="modal-footer">
+			<a ui-turn-off="modalKML" class="btn btn-default">Cancel</a>
+		</div>
+	  </div>
+		  </div>
+	</div>
+  </div>
 </div>
 

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -255,8 +255,8 @@
 				<div class="row">
 					<p ui-state="prepare" ui-class="{'text-primary': prepare}"></p>
 					<div class="btn-group">
-						<a ui-turn-on="prepare" ui-class="{'active': !prepare}" class="btn btn-default" ng-click="downloadTimeKML()" style="margin-right: 5px">Prepare Time KML</a>
-						<a ui-toggle="prepare" ui-class="{'active': !prepare}"  class="btn btn-default" ng-click="downloadAltitudeKML(); " style="margin-right: 5px">Prepare Altitude KML</a>
+						<a ui-turn-on="prepare" ui-class="{'active': !prepare}" class="btn btn-default" ng-click="downloadTimeKML()" style="margin-right: 5px">Download Time KML</a>
+						<a ui-toggle="prepare" ui-class="{'active': !prepare}"  class="btn btn-default" ng-click="downloadAltitudeKML(); " style="margin-right: 5px">Download Altitude KML</a>
 						<a ui-class="{'active': prepare}" ng-show="download" class="btn btn-default ng-cloak">Processing Replay Log...</a>
 					</div>
 				</div>

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -145,8 +145,13 @@
 				</div>
 				<div class="form-group reset-flow">
 					<label class="control-label col-xs-7">Write GPS to file</label>
-					<div class="col-xs-5">
-						<ui-switch ng-model='GPS_Track_Enabled' settings-change></ui-switch>
+					<div class="row">
+						<div class="col-xs-2">
+							<ui-switch ng-model='GPS_Track_Enabled' settings-change></ui-switch>
+						</div>
+						<div class="col-xs-3">
+							<button class="btn btn-primary btn-block" ng-click="downloadOwnshipKML()">Get KML</button>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -243,7 +243,13 @@
 		</div>
 		<div class="modal-body">
 		  <p>Do you want to download a KML version of the replay log?</p>
-		  <p>Your two options are you download KML file based on time, or one that allows you filter traffic based on the altitude of the traffic.</p>
+		  <p>Two animations options are available for download:</p>
+			<ul><li><strong>Time animation:</strong>Traffic animation based on GPS time. I recommend setting the left most slider to the earliest time,
+				then clicking the 'Wrench Icon' to set the 'End date/time' as around 5 minuets later.
+				This will give the traffic animations tails that fade over time and a rough estimation of speed based on the length of tail.</li>
+			<li><strong>Altitude animation:</strong>"Use the Time Animation Slider in the top left of Google Earth to filter traffic based on minimum altitude.
+				Viewing earlier times shows traffic lower minimum altitude, later times a higher minimum altitude. This is useful to filter out cruise traffic in busy
+				airspace by dragging the right most slider towards the left.</li></ul>
 			<div class="panel-body">
 				<div class="separator"></div>
 				<div class="row">

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -244,11 +244,11 @@
 		<div class="modal-body">
 		  <p>Do you want to download a KML version of the replay log?</p>
 		  <p>Two animations options are available for download:</p>
-			<ul><li><strong>Time animation:</strong>Traffic animation based on GPS time. I recommend setting the left most slider to the earliest time,
-				then clicking the 'Wrench Icon' to set the 'End date/time' as around 5 minuets later.
+			<ul><li><strong>Time animation:</strong>Traffic animation based on GPS time. In Google Earth setting the left most slider to the earliest time,
+				then clicking the <strong>Wrench Icon</strong> to set the <code>End date/time<code> as 3 minuets later.
 				This will give the traffic animations tails that fade over time and a rough estimation of speed based on the length of tail.</li>
-			<li><strong>Altitude animation:</strong>"Use the Time Animation Slider in the top left of Google Earth to filter traffic based on minimum altitude.
-				Viewing earlier times shows traffic lower minimum altitude, later times a higher minimum altitude. This is useful to filter out cruise traffic in busy
+			<li><strong>Altitude animation:</strong>Use the Time Animation Slider in the top left of Google Earth to filter traffic based on minimum altitude.
+				Viewing earlier times will display traffic lower minimum altitude, later times a higher minimum altitude. This is useful to filter out cruise traffic in busy
 				airspace by dragging the right most slider towards the left.</li></ul>
 			<div class="panel-body">
 				<div class="separator"></div>

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -231,8 +231,8 @@
 		  <p>Do you want to download a KML version of the replay log?</p>
 		  <p>Your two options are you download KML file based on time, or one that allows you filter traffic based on the altitude of the traffic.</p>
 			<div class="separator">
-			<a ng-click="dowloadTimeKML()" ng-href="{{ url }}" ui-turn-off="modalKML" class="btn btn-primary">Time KML</a>
-			<a ng-click="dowloadAltitudeKML()" ng-href="{{ url }}" ui-turn-off="modalKML" class="btn btn-primary">Altitude KML</a>
+				<a ng-click="downloadTimeKML()" ng-href="{{ url }}" ui-turn-off="modalKML" class="btn btn-primary">Time KML</a>
+				<a ng-click="downloadAltitudeKML()" ng-href="{{ url }}" ui-turn-off="modalKML" class="btn btn-primary">Altitude KML</a>
 			</div>
 		</div>
 		  <div class="modal-footer">

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -154,6 +154,9 @@
 						</div>
 					</div>
 				</div>
+				<div ng-show="download" class="form-group reset-flow ng-cloak">
+					<span  class="fake-btn fake-btn-block">Processing Ownship...</span>
+				</div>
 			</div>
 		</div>
 	</div>
@@ -248,7 +251,7 @@
 					<div class="btn-group">
 						<a ui-turn-on="prepare" ui-class="{'active': !prepare}" class="btn btn-default" ng-click="downloadTimeKML()" style="margin-right: 5px">Prepare Time KML</a>
 						<a ui-toggle="prepare" ui-class="{'active': !prepare}"  class="btn btn-default" ng-click="downloadAltitudeKML(); " style="margin-right: 5px">Prepare Altitude KML</a>
-						<a ui-class="{'active': prepare}" ng-show="download" class="btn btn-default ng-cloak">Procssing Replay Log...</a>
+						<a ui-class="{'active': prepare}" ng-show="download" class="btn btn-default ng-cloak">Processing Replay Log...</a>
 					</div>
 				</div>
 			</div>

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -230,13 +230,20 @@
 		<div class="modal-body">
 		  <p>Do you want to download a KML version of the replay log?</p>
 		  <p>Your two options are you download KML file based on time, or one that allows you filter traffic based on the altitude of the traffic.</p>
-			<div class="separator">
-				<a ng-click="downloadTimeKML()" ng-href="{{ url }}" ui-turn-off="modalKML" class="btn btn-primary">Time KML</a>
-				<a ng-click="downloadAltitudeKML()" ng-href="{{ url }}" ui-turn-off="modalKML" class="btn btn-primary">Altitude KML</a>
+			<div class="panel-body">
+				<div class="separator"></div>
+				<div class="row">
+					<p ui-state="prepare" ui-class="{'text-primary': prepare}"></p>
+					<div class="btn-group">
+						<a ui-turn-on="prepare" ui-class="{'active': !prepare}" class="btn btn-default" ng-click="downloadTimeKML()" style="margin-right: 5px">Prepare Time KML</a>
+						<a ui-toggle="prepare" ui-class="{'active': !prepare}"  class="btn btn-default" ng-click="downloadAltitudeKML(); " style="margin-right: 5px">Prepare Altitude KML</a>
+						<a ui-class="{'active': prepare}" ng-show="download" class="btn btn-default ng-cloak">Procssing Replay Log...</a>
+					</div>
+				</div>
 			</div>
 		</div>
 		  <div class="modal-footer">
-			<a ui-turn-off="modalKML" class="btn btn-default">Cancel</a>
+			<a ui-turn-off="modalKML" class="btn btn-default">Close</a>
 		</div>
 	  </div>
 		  </div>

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -57,8 +57,7 @@
 			</div>
 		</div>
 	</div>
-</div>
-	
+
 <div class="col-sm-12">
 	<div class="panel-group col-sm-6">
 		<div class="panel panel-default">
@@ -108,12 +107,35 @@
 				</div>
 				<div class="form-group reset-flow">
 					<div class="col-xs-12">
-	  				  <button class="btn btn-primary btn-block" ui-turn-on="modalReboot">Reboot</button> 				
-	  				 </div>
+					  <button class="btn btn-primary btn-block" ui-turn-on="modalReboot">Reboot</button>
+					 </div>
 				</div>
 				<div class="form-group reset-flow">
 					<div class="col-xs-12">
 						<button class="btn btn-primary btn-block"ui-turn-on="modalShutdown">Shutdown</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="panel-group col-sm-6">
+		<div class="panel panel-default">
+			<div class="panel-heading">GPS Track File</div>
+			<div class="panel-body">
+				<div class="form-group reset-flow">
+					<label class="control-label col-xs-7">Output format</label>
+					<form name="formatForm" ng-submit="updategpsformat()" novalidate>
+						<select class="col-xs-5"
+								ng-model="GPS_Track_Format"
+								ng-options="option for option in format_options"
+								ng-blur="updategpsformat()">
+						</select>
+					</form>
+				</div>
+				<div class="form-group reset-flow">
+					<label class="control-label col-xs-7">Write GPS to file</label>
+					<div class="col-xs-5">
+						<ui-switch ng-model='GPS_Track_Enabled' settings-change></ui-switch>
 					</div>
 				</div>
 			</div>
@@ -136,57 +158,57 @@
 -->
  
 <div class="col-sm-12">
- 	<h3 ui-if="rebooting" ui-state="rebooting">Stratux is rebooting.  You may need to reconnect WiFi once it reboots.</h3>
-   	<h3 ui-if="shuttingdown" ui-state="shuttingdown">Stratux is shutting down.  You may disconnect power.</h3>
+	<h3 ui-if="rebooting" ui-state="rebooting">Stratux is rebooting.  You may need to reconnect WiFi once it reboots.</h3>
+	<h3 ui-if="shuttingdown" ui-state="shuttingdown">Stratux is shutting down.  You may disconnect power.</h3>
 </div>
 
 <div ui-content-for="modals">
   <div class="modal" ui-if="modalReboot" ui-state="modalReboot">
-    <div class="modal-overlay "></div>
-       	<div class="vertical-alignment-helper center-block">
-        	<div class="modal-dialog vertical-align-center">
-     
-      <div class="modal-content">
-        <div class="modal-header">
-          <button class="close" 
-                  ui-turn-off="modalReboot"></button>
-          <h4 class="modal-title">Are you really sure?</h4>
-        </div>
-        <div class="modal-body">
-          <p>Do you wish to reboot the Stratux?</p>
-          <p>Note that the system will reboot immediately and it will stop responding during the reboot</p>
-        </div>
-        <div class="modal-footer">
-          <a ui-turn-off="modalReboot" class="btn btn-default">Cancel</a>
-          <a ng-click="postReboot()" ui-turn-off="modalReboot" ui-turn-on="rebooting" class="btn btn-primary">Reboot</a>
-        </div>
-      </div>
-    	  </div>
-    </div>
+	<div class="modal-overlay "></div>
+		<div class="vertical-alignment-helper center-block">
+			<div class="modal-dialog vertical-align-center">
+
+	  <div class="modal-content">
+		<div class="modal-header">
+		  <button class="close"
+				  ui-turn-off="modalReboot"></button>
+		  <h4 class="modal-title">Are you really sure?</h4>
+		</div>
+		<div class="modal-body">
+		  <p>Do you wish to reboot the Stratux?</p>
+		  <p>Note that the system will reboot immediately and it will stop responding during the reboot</p>
+		</div>
+		<div class="modal-footer">
+		  <a ui-turn-off="modalReboot" class="btn btn-default">Cancel</a>
+		  <a ng-click="postReboot()" ui-turn-off="modalReboot" ui-turn-on="rebooting" class="btn btn-primary">Reboot</a>
+		</div>
+	  </div>
+		  </div>
+	</div>
   </div>
   
   <div class="modal" ui-if="modalShutdown" ui-state="modalShutdown">
-    <div class="modal-overlay "></div>
-       	<div class="vertical-alignment-helper center-block">
-        	<div class="modal-dialog vertical-align-center">
-     
-      <div class="modal-content">
-        <div class="modal-header">
-          <button class="close" 
-                  ui-turn-off="modalShutdown"></button>
-          <h4 class="modal-title">Are you really sure?</h4>
-        </div>
-        <div class="modal-body">
-          <p>Do you wish to shutdown the Stratux?</p>
-          <p>Note that the system will shutdown immediately. Please disconnect the power after the shutdown.</p>
-        </div>
-        <div class="modal-footer">
-          <a ui-turn-off="modalShutdown" class="btn btn-default">Cancel</a>
-          <a ng-click="postShutdown()" ui-turn-off="modalShutdown" ui-turn-on="shuttingdown" class="btn btn-primary">Shutdown</a>
-        </div>
-      </div>
-    	  </div>
-    </div>
+	<div class="modal-overlay "></div>
+		<div class="vertical-alignment-helper center-block">
+			<div class="modal-dialog vertical-align-center">
+
+	  <div class="modal-content">
+		<div class="modal-header">
+		  <button class="close"
+				  ui-turn-off="modalShutdown"></button>
+		  <h4 class="modal-title">Are you really sure?</h4>
+		</div>
+		<div class="modal-body">
+		  <p>Do you wish to shutdown the Stratux?</p>
+		  <p>Note that the system will shutdown immediately. Please disconnect the power after the shutdown.</p>
+		</div>
+		<div class="modal-footer">
+		  <a ui-turn-off="modalShutdown" class="btn btn-default">Cancel</a>
+		  <a ng-click="postShutdown()" ui-turn-off="modalShutdown" ui-turn-on="shuttingdown" class="btn btn-primary">Shutdown</a>
+		</div>
+	  </div>
+		  </div>
+	</div>
   </div> 
 
 </div>

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -245,7 +245,7 @@
 		  <p>Do you want to download a KML version of the replay log?</p>
 		  <p>Two animations options are available for download:</p>
 			<ul><li><strong>Time animation:</strong>Traffic animation based on GPS time. In Google Earth setting the left most slider to the earliest time,
-				then clicking the <strong>Wrench Icon</strong> to set the <code>End date/time<code> as 3 minuets later.
+				then clicking the <strong>Wrench Icon</strong> to set the <code>End date/time</code> as 3 minuets later.
 				This will give the traffic animations tails that fade over time and a rough estimation of speed based on the length of tail.</li>
 			<li><strong>Altitude animation:</strong>Use the Time Animation Slider in the top left of Google Earth to filter traffic based on minimum altitude.
 				Viewing earlier times will display traffic lower minimum altitude, later times a higher minimum altitude. This is useful to filter out cruise traffic in busy


### PR DESCRIPTION
Changes to the Settings page allows the user to dump the ReplayLog (traffic+ownship) SQLite file or in the new "GPS Track File" panel to just dump the ownship  `mySituation` GPS data. The new 'Write GPS to file' setting only writes the `mySituation` portion of ReplayLog to limit the growth of the stratux.sqlite file size.

The ReplayLog KML file can be created with animations based on time, or altitude. The altitude filter is useful to remove cruise traffic and view traffic below. Demo: https://zippy.gfycat.com/OfficialFirstChinesecrocodilelizard.webm

The KML files have folders based on the following criteria:
- ownship
- ADS-B Traffic w/min alt < FL180
- ADS-B Traffic w/min alt > FL180
- UAT Traffic (`TARGET_TYPE>1`)

Clicking on traffic trails will display minimum and maximum altitude and provide links to Flightaware.

The only thing I think I am missing is a way to clear the SQLite file from the web UI to either free up space or when starting a new flight.
