### PR TITLE
Added capability for a custom SSID. 

### DIFF
--- a/image/hostapd-edimax.conf
+++ b/image/hostapd-edimax.conf
@@ -1,6 +1,5 @@
 interface=wlan0
 driver=rtl871xdrv
-ssid=stratux
 hw_mode=g
 channel=1
 wme_enabled=1

--- a/image/hostapd.conf
+++ b/image/hostapd.conf
@@ -1,5 +1,4 @@
 interface=wlan0
-ssid=stratux
 hw_mode=g
 channel=1
 wmm_enabled=1

--- a/image/stratux-wifi.sh
+++ b/image/stratux-wifi.sh
@@ -9,6 +9,8 @@
 # Detect RPi version.
 #  Per http://elinux.org/RPi_HardwareHistory
 
+DAEMON_CUSTOM_SSID=/etc/hostapd/ssid.conf
+DAEMON_TMP=/tmp/hostapd.conf
 DAEMON_CONF=/etc/hostapd/hostapd.conf
 DAEMON_SBIN=/usr/sbin/hostapd
 EW7811Un=$(lsusb | grep EW-7811Un)
@@ -21,8 +23,16 @@ else
  DAEMON_CONF=/etc/hostapd/hostapd.conf
 fi
 
+cp -f ${DAEMON_CONF} ${DAEMON_TMP}
 
-${DAEMON_SBIN} -B ${DAEMON_CONF}
+SSID="stratux"
+
+if [ -e "${DAEMON_CUSTOM_SSID}" ]; then
+	SSID="$(cat ${DAEMON_CUSTOM_SSID})"
+fi
+#Append the SSID to the configuration file
+echo "ssid=$SSID" >> ${DAEMON_TMP}
+${DAEMON_SBIN} -B ${DAEMON_TMP}
 
 sleep 5
 


### PR DESCRIPTION
If the file /etc/hostapd/ssid.conf exists, it uses the contents of this file for the SSID instead of stratux

This allows the updating of the software and allowing the use of a custom SSID
