### PR TITLE
Possible solution for upper level winds forecast time

### DIFF
--- a/web/plates/js/weather.js
+++ b/web/plates/js/weather.js
@@ -140,7 +140,12 @@ function WeatherCtrl($rootScope, $scope, $state, $http, $interval) {
 		var dNow = new Date();
 		var dThen = parseShortDatetime(obj.Time);
 		data_item.age = dThen.getTime();
-		data_item.time = deltaTimeString(dNow - dThen) + " old";
+        	if (obj.Type == "WINDS") {
+	            data_item.time = deltaTimeString(dThen - dNow) + " from now";
+	        } else {
+	            data_item.time = deltaTimeString(dNow - dThen) + " old";
+	        }
+        
 		// data_item.received = utcTimeString(obj.LocaltimeReceived);
 		data_item.data = obj.Data;
 	}


### PR DESCRIPTION
The WINDS forecast will show 'from now' instead of '29 days ago'. It may not be the right solution, but at least this is a good placeholder for a change