### PR TITLE
GDL90 JSON interface stratux changes

### DIFF
--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -35,6 +35,25 @@ type SettingMessage struct {
 // Weather updates channel.
 var weatherUpdate *uibroadcaster
 var trafficUpdate *uibroadcaster
+var gdl90Update *uibroadcaster
+
+func handleGdl90WS(conn *websocket.Conn) {
+	// Subscribe the socket to receive updates.
+	gdl90Update.AddSocket(conn)
+
+	// Connection closes when function returns. Since uibroadcast is writing and we don't need to read anything (for now), just keep it busy.
+	for {
+		buf := make([]byte, 1024)
+		_, err := conn.Read(buf)
+		if err != nil {
+			break
+		}
+		if buf[0] != 0 { // Dummy.
+			continue
+		}
+		time.Sleep(1 * time.Second)
+	}
+}
 
 /*
 	The /weather websocket starts off by sending the current buffer of weather messages, then sends updates as they are received.
@@ -482,11 +501,18 @@ func viewLogs(w http.ResponseWriter, r *http.Request) {
 func managementInterface() {
 	weatherUpdate = NewUIBroadcaster()
 	trafficUpdate = NewUIBroadcaster()
+    	gdl90Update = NewUIBroadcaster()
 
 	http.HandleFunc("/", defaultServer)
 	http.Handle("/logs/", http.StripPrefix("/logs/", http.FileServer(http.Dir("/var/log"))))
 	http.HandleFunc("/view_logs/", viewLogs)
 
+	http.HandleFunc("/gdl90",
+		func(w http.ResponseWriter, req *http.Request) {
+			s := websocket.Server{
+				Handler: websocket.Handler(handleGdl90WS)}
+			s.ServeHTTP(w, req)
+		})
 	http.HandleFunc("/status",
 		func(w http.ResponseWriter, req *http.Request) {
 			s := websocket.Server{

--- a/main/network.go
+++ b/main/network.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv4"
 	"io/ioutil"
+	"encoding/json"
 	"log"
 	"math"
 	"math/rand"

--- a/main/network.go
+++ b/main/network.go
@@ -143,7 +143,7 @@ func sendToAllConnectedClients(msg networkMessage) {
 	if (msg.msgType & NETWORK_GDL90_STANDARD) != 0 {
 		// It's a GDL90 message. Send to serial output channel (which may or may not cause something to happen).
 		serialOutputChan <- msg.msg
-                networkGDL90Chan <- msg.msg
+		networkGDL90Chan <- msg.msg
 	}
 
 	netMutex.Lock()
@@ -196,14 +196,15 @@ var serialOutputChan chan []byte
 var networkGDL90Chan chan []byte
 
 func networkOutWatcher() {
-    //ticker := time.NewTicker(10 * time.Second)
-    //var nmsg gdl90NetMessage
-    for {
-        select {
-            case ch := <-networkGDL90Chan:
-            	gdl90Update.SendJSON(ch)
-        }
-    }
+	//ticker := time.NewTicker(10 * time.Second)
+	//var nmsg gdl90NetMessage
+	for {
+		select {
+		case ch := <-networkGDL90Chan:
+			gdlJSON, _ := json.Marshal(ch)
+			gdl90Update.Send(gdlJSON)
+		}
+	}
 }
 
 // Monitor serial output channel, send to serial port.
@@ -616,7 +617,7 @@ func ffMonitor() {
 func initNetwork() {
 	messageQueue = make(chan networkMessage, 1024) // Buffered channel, 1024 messages.
 	serialOutputChan = make(chan []byte, 1024)     // Buffered channel, 1024 GDL90 messages.
-        networkGDL90Chan = make(chan []byte, 1024)
+	networkGDL90Chan = make(chan []byte, 1024)
 	outSockets = make(map[string]networkConnection)
 	pingResponse = make(map[string]time.Time)
 	netMutex = &sync.Mutex{}

--- a/main/network.go
+++ b/main/network.go
@@ -143,6 +143,7 @@ func sendToAllConnectedClients(msg networkMessage) {
 	if (msg.msgType & NETWORK_GDL90_STANDARD) != 0 {
 		// It's a GDL90 message. Send to serial output channel (which may or may not cause something to happen).
 		serialOutputChan <- msg.msg
+                networkGDL90Chan <- msg.msg
 	}
 
 	netMutex.Lock()
@@ -192,6 +193,18 @@ func sendToAllConnectedClients(msg networkMessage) {
 }
 
 var serialOutputChan chan []byte
+var networkGDL90Chan chan []byte
+
+func networkOutWatcher() {
+    //ticker := time.NewTicker(10 * time.Second)
+    //var nmsg gdl90NetMessage
+    for {
+        select {
+            case ch := <-networkGDL90Chan:
+            	gdl90Update.SendJSON(ch)
+        }
+    }
+}
 
 // Monitor serial output channel, send to serial port.
 func serialOutWatcher() {
@@ -603,6 +616,7 @@ func ffMonitor() {
 func initNetwork() {
 	messageQueue = make(chan networkMessage, 1024) // Buffered channel, 1024 messages.
 	serialOutputChan = make(chan []byte, 1024)     // Buffered channel, 1024 GDL90 messages.
+        networkGDL90Chan = make(chan []byte, 1024)
 	outSockets = make(map[string]networkConnection)
 	pingResponse = make(map[string]time.Time)
 	netMutex = &sync.Mutex{}
@@ -612,4 +626,5 @@ func initNetwork() {
 	go sleepMonitor()
 	go networkStatsCounter()
 	go serialOutWatcher()
+	go networkOutWatcher()
 }


### PR DESCRIPTION
This encapsulates GDL90 traffic over a websocket for broadcasting to remote hosts. The remote host can connect to a stratux over the internet and receive the GDL90 to be rebroadcasted on its local network over UDP. This will be used for remote developers so they can use a remote stratux for software development of Android or iPad applications using real data.