### PR TITLE
Move user configurable options out of hostapd.conf and hostapd-edimax.conf to hostapd.user and build temp hoatapd.conf on the fly with stratux-wifi.sh

### DIFF
--- a/__root__stratux-pre-start.sh
+++ b/__root__stratux-pre-start.sh
@@ -15,3 +15,39 @@ if [ -e /root/update*stratux*v*.sh ] ; then
 	fi
 fi
 
+##### Script for setting up new file structure for hostapd settings
+##### Look for hostapd.user and if found do nothing.
+##### If not assume because of previous version and convert to new file structure
+DAEMON_USER_PREF=/etc/hostapd/hostapd.user
+if [ ! -f $DAEMON_USER_PREF ]; then
+	DAEMON_CONF=/etc/hostapd/hostapd.conf
+    DAEMON_CONF_EDIMAX=/etc/hostapd/hostapd-edimax.conf
+	HOSTAPD_VALUES=('ssid=' 'channel=' 'auth_algs=' 'wpa=' 'wpa_passphrase=' 'wpa_key_mgmt=' 'wpa_pairwise=' 'rsn_pairwise=')
+	HOSTAPD_VALUES_RM=('#auth_algs=' '#wpa=' '#wpa_passphrase=' '#wpa_key_mgmt=' '#wpa_pairwise=' '#rsn_pairwise=')
+	
+	for i in "${HOSTAPD_VALUES[@]}" 
+	do
+    	if grep -q "^$i" $DAEMON_CONF
+		then
+        	grep "^$i" $DAEMON_CONF >> $DAEMON_USER_PREF
+        	sed -i '/^'"$i"'/d' $DAEMON_CONF
+			sed -i '/^'"$i"'/d' $DAEMON_CONF_EDIMAX
+		fi
+	done
+	for i in "${HOSTAPD_VALUES_RM[@]}"
+	do
+    	if grep -q "^$i" $DAEMON_CONF
+		then
+			sed -i '/^'"$i"'/d' $DAEMON_CONF
+			sed -i '/^'"$i"'/d' $DAEMON_CONF_EDIMAX
+		fi
+	done
+    sleep 1     #make sure there is time to get the file written before checking for it again
+    # If once the code above runs and there is still no hostapd.user file then something is wrong and we will just create the file with basic settings. 
+    # Any more then this they somebody was messing with things and its not our fault things are this bad
+	if [ ! -f $DAEMON_USER_PREF ]; then 
+		echo "ssid=stratux" >> $DAEMON_USER_PREF
+	    echo "channel=1" >> $DAEMON_USER_PREF
+	fi
+fi
+##### End hostapd settings structure script

--- a/image/hostapd-edimax.conf
+++ b/image/hostapd-edimax.conf
@@ -1,8 +1,6 @@
 interface=wlan0
 driver=rtl871xdrv
-ssid=stratux
 hw_mode=g
-channel=1
 wme_enabled=1
 ieee80211n=1
 ignore_broadcast_ssid=0

--- a/image/hostapd.conf
+++ b/image/hostapd.conf
@@ -1,7 +1,5 @@
 interface=wlan0
-ssid=stratux
 hw_mode=g
-channel=1
 wmm_enabled=1
 ieee80211n=1
 ignore_broadcast_ssid=0

--- a/image/hostapd.user
+++ b/image/hostapd.user
@@ -1,2 +1,0 @@
-ssid=stratux
-channel=1

--- a/image/hostapd.user
+++ b/image/hostapd.user
@@ -1,0 +1,2 @@
+ssid=stratux
+channel=1

--- a/image/hostapd_manager.sh
+++ b/image/hostapd_manager.sh
@@ -90,7 +90,7 @@ while getopts $options option; do
           OPT_C=$OPTARG
           echo "$parm Channel option -c used: $OPT_C"
           if [[ "$OPT_C" =~ ^[0-9]+$ ]] && [ "$OPT_C" -ge 1 -a "$OPT_C" -le 13  ]; then
-          	echo "${GREEN}    Channel will now be set to ${BOLD}${UNDR}$OPT_C.${WHITE}${NORMAL}"
+          	echo "${GREEN}    Channel will now be set to ${BOLD}${UNDR}$OPT_C${NORMAL}.${WHITE}${NORMAL}"
           else
             echo "${BOLD}${RED}$err Channel is not within acceptable values, exiting...${WHITE}${NORMAL}"
             exit 1
@@ -254,9 +254,31 @@ do
     echo ""
   fi
 done
-echo "${YELLOW}$att Don't forget to reboot... $att ${WHITE}"
+echo "${RED}${BOLD} $att At this time the script will restart your WiFi services. $att ${WHITE}${NORMAL}"
+echo "If you are connected to Stratux through the ${BOLD}192.168.10.1${NORMAL} interface then you will be disconnected"
+echo "Please wait 1 min and look for the new SSID on your wireless device."
+sleep 3
+echo "${YELLOW}$att Restarting Stratux WiFi Services... $att ${WHITE}"
+echo "Killing hostapd..."
+/usr/bin/killall -9 hostapd hostapd-edimax
+echo "Killed..."
+echo ""
+echo "Killing DHCP Server..."
+echo ""
+/usr/sbin/service isc-dhcp-server stop
+sleep 0.5
+echo "Killed..."
+echo ""
+echo "ifdown wlan0..."
+ifdown wlan0
+sleep 0.5
+echo "ifup wlan0..."
+echo "Calling Stratux WiFI Start Script(stratux-wifi.sh)..."
+ifup wlan0
+sleep 0.5
 echo ""
 echo ""
+echo "All systems should be up and running and you should see your new SSID!"
 
 ### End main loop ###
 

--- a/image/hostapd_manager.sh
+++ b/image/hostapd_manager.sh
@@ -69,7 +69,7 @@ fi
 #If an option should be followed by an argument, it should be followed by a ":".
 #Notice there is no ":" after "oqh". The leading ":" suppresses error messages from
 #getopts. This is required to get my unrecognized option code to work.
-options=':s:c:e:oqh'
+options=':s:c:eoqh'
 while getopts $options option; do
   case $option in
     s)  #set option "s"
@@ -90,7 +90,7 @@ while getopts $options option; do
           OPT_C=$OPTARG
           echo "$parm Channel option -c used: $OPT_C"
           if [[ "$OPT_C" =~ ^[0-9]+$ ]] && [ "$OPT_C" -ge 1 -a "$OPT_C" -le 13  ]; then
-          	echo "${GREEN}    Channel will now be set to ${BOLD}${UNDR}$OPT_C${NORMAL}.${WHITE}${NORMAL}"
+          	echo "${GREEN}    Channel will now be set to ${BOLD}${UNDR}$OPT_C${WHITE}${NORMAL}."
           else
             echo "${BOLD}${RED}$err Channel is not within acceptable values, exiting...${WHITE}${NORMAL}"
             exit 1
@@ -99,8 +99,8 @@ while getopts $options option; do
       ;;
     e)  #set option "e"
       if [[ -z "${OPTARG}" || "${OPTARG}" == *[[:space:]]* || "${OPTARG}" == -* ]]; then
-          echo "${BOLD}${RED}$err Encryption option(-e) used without passphrase, exiting...${WHITE}${NORMAL}"
-          exit 1
+          echo "${BOLD}${RED}$err Encryption option(-e) used without passphrase, Passphrase will be set to ${BOLD}$defaultPass${NORMAL}...${WHITE}${NORMAL}"
+          OPT_E=$defaultPass
       else
         OPT_E=$OPTARG
         echo "$parm Encryption option -e used:"
@@ -126,7 +126,7 @@ while getopts $options option; do
       HELP
       ;;
    \?) # invalid option
-     echo "${BOLD}${RED}$err Invalid option -$OPTARG" >&2
+     echo "${BOLD}${RED}$err Invalid option -$OPTARG ${WHITE}${NORMAL}" >&2
      exit 1
      ;;
    :) # Missing Arg 
@@ -254,7 +254,7 @@ do
     echo ""
   fi
 done
-echo "${RED}${BOLD} $att At this time the script will restart your WiFi services. $att ${WHITE}${NORMAL}"
+echo "${RED}${BOLD} $att At this time the script will restart your WiFi services.${WHITE}${NORMAL}"
 echo "If you are connected to Stratux through the ${BOLD}192.168.10.1${NORMAL} interface then you will be disconnected"
 echo "Please wait 1 min and look for the new SSID on your wireless device."
 sleep 3

--- a/image/hostapd_manager.sh
+++ b/image/hostapd_manager.sh
@@ -161,7 +161,7 @@ echo "${BOLD}No errors found. Continuning...${NORMAL}"
 echo ""
 
 # files to edit
-HOSTAPD=('/etc/hostapd/hostapd.conf' '/etc/hostapd/hostapd-edimax.conf')
+HOSTAPD=('/etc/hostapd/hostapd.user')
 
 ####
 #### File modification loop

--- a/image/stratux-wifi.sh
+++ b/image/stratux-wifi.sh
@@ -59,8 +59,6 @@ if [ "$RPI_REV" = "a01041" ] || [ "$RPI_REV" = "a21041" ] || [ "$RPI_REV" = "900
  # This is a RPi2B or RPi0 with Edimax USB Wifi dongle.
  DAEMON_CONF=/etc/hostapd/hostapd-edimax.conf
  DAEMON_SBIN=/etc/hostapd/hostapd-edimax
-# else
-#  DAEMON_CONF=/etc/hostapd/hostapd.conf
 fi
 
 #Make a new hostapd or hostapd-edimax conf file based on logic above

--- a/image/stratux-wifi.sh
+++ b/image/stratux-wifi.sh
@@ -43,6 +43,10 @@ if [ ! -f $DAEMON_USER_PREF ]; then
             	sed -i '/^'"$i"'/d' $DAEMON_CONF_EDIMAX
 		fi
 	done
+	
+	#make sure there is time to get the file written before checking for it again
+    	sleep 1
+	
 	# If once the code above runs and there is still no hostapd.user file then something is wrong and we will just create the file with basic settings. 
 	#Any more then this they somebody was messing with things and its not our fault things are this bad
 	if [ ! -f $DAEMON_USER_PREF ]; then 
@@ -69,6 +73,6 @@ cat ${DAEMON_USER_PREF} >> ${DAEMON_TMP}
 
 ${DAEMON_SBIN} -B ${DAEMON_TMP}
 
-sleep 5
+sleep 3
 
 /usr/sbin/service isc-dhcp-server start

--- a/image/stratux-wifi.sh
+++ b/image/stratux-wifi.sh
@@ -8,21 +8,32 @@
 
 # Detect RPi version.
 #  Per http://elinux.org/RPi_HardwareHistory
-
+#Assume PI3 settings
 DAEMON_CONF=/etc/hostapd/hostapd.conf
 DAEMON_SBIN=/usr/sbin/hostapd
+
+#User settings for hostapd.conf and hostapd-edimax.conf
+DAEMON_USER_PREF=/etc/hostapd/hostapd.user
+
+DAEMON_TMP=/tmp/hostapd.conf
+
 EW7811Un=$(lsusb | grep EW-7811Un)
 RPI_REV=`cat /proc/cpuinfo | grep 'Revision' | awk '{print $3}' | sed 's/^1000//'`
 if [ "$RPI_REV" = "a01041" ] || [ "$RPI_REV" = "a21041" ] || [ "$RPI_REV" = "900092" ] || [ "$RPI_REV" = "900093" ] && [ "$EW7811Un" != '' ]; then
  # This is a RPi2B or RPi0 with Edimax USB Wifi dongle.
  DAEMON_CONF=/etc/hostapd/hostapd-edimax.conf
- DAEMON_SBIN=/usr/sbin/hostapd-edimax
-else
- DAEMON_CONF=/etc/hostapd/hostapd.conf
+ DAEMON_SBIN=/etc/hostapd/hostapd-edimax
+# else
+#  DAEMON_CONF=/etc/hostapd/hostapd.conf
 fi
 
+#Make a new hostapd or hostapd-edimax conf file based on logic above
+cp -f ${DAEMON_CONF} ${DAEMON_TMP}
 
-${DAEMON_SBIN} -B ${DAEMON_CONF}
+#inject user settings from file to tmp conf
+cat ${DAEMON_USER_PREF} >> ${DAEMON_TMP}
+
+${DAEMON_SBIN} -B ${DAEMON_TMP}
 
 sleep 5
 

--- a/image/stratux-wifi.sh
+++ b/image/stratux-wifi.sh
@@ -50,7 +50,7 @@ fi
 # If once the code above runs and there is still no hostapd.user file then something is wrong and we will just create the file with basic settings. 
 #Any more then this they somebody was messing with things and its not our fault things are this bad
 if [ ! -f $DAEMON_USER_PREF ]; then 
-	echo $"ssid=stratux\nchannel=1\n" >> $DAEMON_USER_PREF
+	echo $"ssid=stratux\nchannel=1" >> $DAEMON_USER_PREF
 fi
 # Detect RPi version.
 #  Per http://elinux.org/RPi_HardwareHistory

--- a/image/stratux-wifi.sh
+++ b/image/stratux-wifi.sh
@@ -45,13 +45,14 @@ if [ ! -f $DAEMON_USER_PREF ]; then
             	sed -i '/^'"$i"'/d' $DAEMON_CONF_EDIMAX
 		fi
 	done
+	# If once the code above runs and there is still no hostapd.user file then something is wrong and we will just create the file with basic settings. 
+	#Any more then this they somebody was messing with things and its not our fault things are this bad
+	if [ ! -f $DAEMON_USER_PREF ]; then 
+		echo "ssid=stratux" >> $DAEMON_USER_PREF
+		echo "channel=1" >> $DAEMON_USER_PREF
+	fi
 fi
 
-# If once the code above runs and there is still no hostapd.user file then something is wrong and we will just create the file with basic settings. 
-#Any more then this they somebody was messing with things and its not our fault things are this bad
-if [ ! -f $DAEMON_USER_PREF ]; then 
-	echo $"ssid=stratux\nchannel=1" >> $DAEMON_USER_PREF
-fi
 # Detect RPi version.
 #  Per http://elinux.org/RPi_HardwareHistory
 EW7811Un=$(lsusb | grep EW-7811Un)

--- a/image/stratux-wifi.sh
+++ b/image/stratux-wifi.sh
@@ -13,48 +13,6 @@ DAEMON_USER_PREF=/etc/hostapd/hostapd.user
 
 DAEMON_TMP=/tmp/hostapd.conf
 
-# This code checks for the existence of ostapd.user and if it exists it leaves it alone.
-# If the file does not exist it copys over the values from the existing hostapd.conf to hostapd.user and removes them
-# check for hostapd.user and if needed create properly
-if [ ! -f $DAEMON_USER_PREF ]; then 
-	# values to move
-	HOSTAPD_VALUES=('ssid=' 'channel=' 'auth_algs=' 'wpa=' 'wpa_passphrase=' 'wpa_key_mgmt=' 'wpa_pairwise=' 'rsn_pairwise=')
-	#values to remove
-	HOSTAPD_VALUES_RM=('#auth_algs=' '#wpa=' '#wpa_passphrase=' '#wpa_key_mgmt=' '#wpa_pairwise=' '#rsn_pairwise=')
-
-	DAEMON_CONF_EDIMAX=/etc/hostapd/hostapd-edimax.conf
-
-	# move any custom values
-	for i in "${HOSTAPD_VALUES[@]}"
-	do
-    		if grep -q "^$i" $DAEMON_CONF
-		then
-        		grep "^$i" $DAEMON_CONF >> $DAEMON_USER_PREF
-        		sed -i '/^'"$i"'/d' $DAEMON_CONF
-			sed -i '/^'"$i"'/d' $DAEMON_CONF_EDIMAX
-		fi
-	done
-# just remove commented values
-	for i in "${HOSTAPD_VALUES_RM[@]}"
-	do
-    		if grep -q "^$i" $DAEMON_CONF
-		then
-        		sed -i '/^'"$i"'/d' $DAEMON_CONF
-            		sed -i '/^'"$i"'/d' $DAEMON_CONF_EDIMAX
-		fi
-	done
-	
-	#make sure there is time to get the file written before checking for it again
-    	sleep 1
-	
-	# If once the code above runs and there is still no hostapd.user file then something is wrong and we will just create the file with basic settings. 
-	#Any more then this they somebody was messing with things and its not our fault things are this bad
-	if [ ! -f $DAEMON_USER_PREF ]; then 
-		echo "ssid=stratux" >> $DAEMON_USER_PREF
-		echo "channel=1" >> $DAEMON_USER_PREF
-	fi
-fi
-
 # Detect RPi version.
 #  Per http://elinux.org/RPi_HardwareHistory
 EW7811Un=$(lsusb | grep EW-7811Un)

--- a/image/stratux-wifi.sh
+++ b/image/stratux-wifi.sh
@@ -8,24 +8,22 @@
 DAEMON_CONF=/etc/hostapd/hostapd.conf
 DAEMON_SBIN=/usr/sbin/hostapd
 
-DAEMON_CONF_EDIMAX=/etc/hostapd/hostapd-edimax.conf
-
 #User settings for hostapd.conf and hostapd-edimax.conf
 DAEMON_USER_PREF=/etc/hostapd/hostapd.user
 
 DAEMON_TMP=/tmp/hostapd.conf
 
-# values to move
-HOSTAPD_VALUES=('ssid=' 'channel=' 'auth_algs=' 'wpa=' 'wpa_passphrase=' 'wpa_key_mgmt=' 'wpa_pairwise=' 'rsn_pairwise=')
-
-#values to remove
-HOSTAPD_VALUES_RM=('#auth_algs=' '#wpa=' '#wpa_passphrase=' '#wpa_key_mgmt=' '#wpa_pairwise=' '#rsn_pairwise=')
-
-
 # This code checks for the existence of ostapd.user and if it exists it leaves it alone.
 # If the file does not exist it copys over the values from the existing hostapd.conf to hostapd.user and removes them
 # check for hostapd.user and if needed create properly
 if [ ! -f $DAEMON_USER_PREF ]; then 
+# values to move
+HOSTAPD_VALUES=('ssid=' 'channel=' 'auth_algs=' 'wpa=' 'wpa_passphrase=' 'wpa_key_mgmt=' 'wpa_pairwise=' 'rsn_pairwise=')
+#values to remove
+HOSTAPD_VALUES_RM=('#auth_algs=' '#wpa=' '#wpa_passphrase=' '#wpa_key_mgmt=' '#wpa_pairwise=' '#rsn_pairwise=')
+
+DAEMON_CONF_EDIMAX=/etc/hostapd/hostapd-edimax.conf
+
 # move any custom values
 	for i in "${HOSTAPD_VALUES[@]}"
 	do

--- a/image/stratux-wifi.sh
+++ b/image/stratux-wifi.sh
@@ -5,9 +5,6 @@
 /usr/bin/killall -9 hostapd hostapd-edimax
 /usr/sbin/service isc-dhcp-server stop
 
-
-# Detect RPi version.
-#  Per http://elinux.org/RPi_HardwareHistory
 #Assume PI3 settings
 DAEMON_CONF=/etc/hostapd/hostapd.conf
 DAEMON_SBIN=/usr/sbin/hostapd
@@ -18,7 +15,8 @@ DAEMON_USER_PREF=/etc/hostapd/hostapd.user
 #temp hostapd.conf
 DAEMON_TMP=/tmp/hostapd.conf
 
-#check for pi2 and change files
+# Detect RPi version.
+#  Per http://elinux.org/RPi_HardwareHistory
 EW7811Un=$(lsusb | grep EW-7811Un)
 RPI_REV=`cat /proc/cpuinfo | grep 'Revision' | awk '{print $3}' | sed 's/^1000//'`
 if [ "$RPI_REV" = "a01041" ] || [ "$RPI_REV" = "a21041" ] || [ "$RPI_REV" = "900092" ] || [ "$RPI_REV" = "900093" ] && [ "$EW7811Un" != '' ]; then

--- a/image/stratux-wifi.sh
+++ b/image/stratux-wifi.sh
@@ -17,14 +17,14 @@ DAEMON_TMP=/tmp/hostapd.conf
 # If the file does not exist it copys over the values from the existing hostapd.conf to hostapd.user and removes them
 # check for hostapd.user and if needed create properly
 if [ ! -f $DAEMON_USER_PREF ]; then 
-# values to move
-HOSTAPD_VALUES=('ssid=' 'channel=' 'auth_algs=' 'wpa=' 'wpa_passphrase=' 'wpa_key_mgmt=' 'wpa_pairwise=' 'rsn_pairwise=')
-#values to remove
-HOSTAPD_VALUES_RM=('#auth_algs=' '#wpa=' '#wpa_passphrase=' '#wpa_key_mgmt=' '#wpa_pairwise=' '#rsn_pairwise=')
+	# values to move
+	HOSTAPD_VALUES=('ssid=' 'channel=' 'auth_algs=' 'wpa=' 'wpa_passphrase=' 'wpa_key_mgmt=' 'wpa_pairwise=' 'rsn_pairwise=')
+	#values to remove
+	HOSTAPD_VALUES_RM=('#auth_algs=' '#wpa=' '#wpa_passphrase=' '#wpa_key_mgmt=' '#wpa_pairwise=' '#rsn_pairwise=')
 
-DAEMON_CONF_EDIMAX=/etc/hostapd/hostapd-edimax.conf
+	DAEMON_CONF_EDIMAX=/etc/hostapd/hostapd-edimax.conf
 
-# move any custom values
+	# move any custom values
 	for i in "${HOSTAPD_VALUES[@]}"
 	do
     	if grep -q "^$i" $DAEMON_CONF

--- a/image/stratux-wifi.sh
+++ b/image/stratux-wifi.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
 # Preliminaries. Kill off old services.
 /usr/bin/killall -9 hostapd hostapd-edimax
 /usr/sbin/service isc-dhcp-server stop
@@ -9,12 +8,51 @@
 DAEMON_CONF=/etc/hostapd/hostapd.conf
 DAEMON_SBIN=/usr/sbin/hostapd
 
+DAEMON_CONF_EDIMAX=/etc/hostapd/hostapd-edimax.conf
+
 #User settings for hostapd.conf and hostapd-edimax.conf
 DAEMON_USER_PREF=/etc/hostapd/hostapd.user
 
-#temp hostapd.conf
 DAEMON_TMP=/tmp/hostapd.conf
 
+# values to move
+HOSTAPD_VALUES=('ssid=' 'channel=' 'auth_algs=' 'wpa=' 'wpa_passphrase=' 'wpa_key_mgmt=' 'wpa_pairwise=' 'rsn_pairwise=')
+
+#values to remove
+HOSTAPD_VALUES_RM=('#auth_algs=' '#wpa=' '#wpa_passphrase=' '#wpa_key_mgmt=' '#wpa_pairwise=' '#rsn_pairwise=')
+
+
+# This code checks for the existence of ostapd.user and if it exists it leaves it alone.
+# If the file does not exist it copys over the values from the existing hostapd.conf to hostapd.user and removes them
+# check for hostapd.user and if needed create properly
+if [ ! -f $DAEMON_USER_PREF ]; then 
+# move any custom values
+	for i in "${HOSTAPD_VALUES[@]}"
+	do
+    	if grep -q "^$i" $DAEMON_CONF
+		then
+        	grep "^$i" $DAEMON_CONF >> $DAEMON_USER_PREF
+            echo "deleting lines..."
+        	sed -i '/^'"$i"'/d' $DAEMON_CONF
+            sed -i '/^'"$i"'/d' $DAEMON_CONF_EDIMAX
+		fi
+	done
+# just remove commented values
+	for i in "${HOSTAPD_VALUES_RM[@]}"
+	do
+    	if grep -q "^$i" $DAEMON_CONF
+		then
+        	sed -i '/^'"$i"'/d' $DAEMON_CONF
+            sed -i '/^'"$i"'/d' $DAEMON_CONF_EDIMAX
+		fi
+	done
+fi
+
+# If once the code above runs and there is still no hostapd.user file then something is wrong and we will just create the file with basic settings. 
+#Any more then this they somebody was messing with things and its not our fault things are this bad
+if [ ! -f $DAEMON_USER_PREF ]; then 
+	echo $"ssid=stratux\nchannel=1\n" >> $DAEMON_USER_PREF
+fi
 # Detect RPi version.
 #  Per http://elinux.org/RPi_HardwareHistory
 EW7811Un=$(lsusb | grep EW-7811Un)
@@ -23,6 +61,8 @@ if [ "$RPI_REV" = "a01041" ] || [ "$RPI_REV" = "a21041" ] || [ "$RPI_REV" = "900
  # This is a RPi2B or RPi0 with Edimax USB Wifi dongle.
  DAEMON_CONF=/etc/hostapd/hostapd-edimax.conf
  DAEMON_SBIN=/etc/hostapd/hostapd-edimax
+# else
+#  DAEMON_CONF=/etc/hostapd/hostapd.conf
 fi
 
 #Make a new hostapd or hostapd-edimax conf file based on logic above
@@ -31,7 +71,6 @@ cp -f ${DAEMON_CONF} ${DAEMON_TMP}
 #inject user settings from file to tmp conf
 cat ${DAEMON_USER_PREF} >> ${DAEMON_TMP}
 
-#start the daemon with the temp file
 ${DAEMON_SBIN} -B ${DAEMON_TMP}
 
 sleep 5

--- a/image/stratux-wifi.sh
+++ b/image/stratux-wifi.sh
@@ -32,9 +32,8 @@ if [ ! -f $DAEMON_USER_PREF ]; then
     	if grep -q "^$i" $DAEMON_CONF
 		then
         	grep "^$i" $DAEMON_CONF >> $DAEMON_USER_PREF
-            echo "deleting lines..."
         	sed -i '/^'"$i"'/d' $DAEMON_CONF
-            sed -i '/^'"$i"'/d' $DAEMON_CONF_EDIMAX
+		sed -i '/^'"$i"'/d' $DAEMON_CONF_EDIMAX
 		fi
 	done
 # just remove commented values
@@ -43,7 +42,7 @@ if [ ! -f $DAEMON_USER_PREF ]; then
     	if grep -q "^$i" $DAEMON_CONF
 		then
         	sed -i '/^'"$i"'/d' $DAEMON_CONF
-            sed -i '/^'"$i"'/d' $DAEMON_CONF_EDIMAX
+            	sed -i '/^'"$i"'/d' $DAEMON_CONF_EDIMAX
 		fi
 	done
 fi

--- a/image/stratux-wifi.sh
+++ b/image/stratux-wifi.sh
@@ -15,16 +15,16 @@ DAEMON_SBIN=/usr/sbin/hostapd
 #User settings for hostapd.conf and hostapd-edimax.conf
 DAEMON_USER_PREF=/etc/hostapd/hostapd.user
 
+#temp hostapd.conf
 DAEMON_TMP=/tmp/hostapd.conf
 
+#check for pi2 and change files
 EW7811Un=$(lsusb | grep EW-7811Un)
 RPI_REV=`cat /proc/cpuinfo | grep 'Revision' | awk '{print $3}' | sed 's/^1000//'`
 if [ "$RPI_REV" = "a01041" ] || [ "$RPI_REV" = "a21041" ] || [ "$RPI_REV" = "900092" ] || [ "$RPI_REV" = "900093" ] && [ "$EW7811Un" != '' ]; then
  # This is a RPi2B or RPi0 with Edimax USB Wifi dongle.
  DAEMON_CONF=/etc/hostapd/hostapd-edimax.conf
  DAEMON_SBIN=/etc/hostapd/hostapd-edimax
-# else
-#  DAEMON_CONF=/etc/hostapd/hostapd.conf
 fi
 
 #Make a new hostapd or hostapd-edimax conf file based on logic above
@@ -33,6 +33,7 @@ cp -f ${DAEMON_CONF} ${DAEMON_TMP}
 #inject user settings from file to tmp conf
 cat ${DAEMON_USER_PREF} >> ${DAEMON_TMP}
 
+#start the daemon with the temp file
 ${DAEMON_SBIN} -B ${DAEMON_TMP}
 
 sleep 5

--- a/image/stratux-wifi.sh
+++ b/image/stratux-wifi.sh
@@ -27,20 +27,20 @@ if [ ! -f $DAEMON_USER_PREF ]; then
 	# move any custom values
 	for i in "${HOSTAPD_VALUES[@]}"
 	do
-    	if grep -q "^$i" $DAEMON_CONF
+    		if grep -q "^$i" $DAEMON_CONF
 		then
-        	grep "^$i" $DAEMON_CONF >> $DAEMON_USER_PREF
-        	sed -i '/^'"$i"'/d' $DAEMON_CONF
-		sed -i '/^'"$i"'/d' $DAEMON_CONF_EDIMAX
+        		grep "^$i" $DAEMON_CONF >> $DAEMON_USER_PREF
+        		sed -i '/^'"$i"'/d' $DAEMON_CONF
+			sed -i '/^'"$i"'/d' $DAEMON_CONF_EDIMAX
 		fi
 	done
 # just remove commented values
 	for i in "${HOSTAPD_VALUES_RM[@]}"
 	do
-    	if grep -q "^$i" $DAEMON_CONF
+    		if grep -q "^$i" $DAEMON_CONF
 		then
-        	sed -i '/^'"$i"'/d' $DAEMON_CONF
-            	sed -i '/^'"$i"'/d' $DAEMON_CONF_EDIMAX
+        		sed -i '/^'"$i"'/d' $DAEMON_CONF
+            		sed -i '/^'"$i"'/d' $DAEMON_CONF_EDIMAX
 		fi
 	done
 	

--- a/selfupdate/makeupdate.sh
+++ b/selfupdate/makeupdate.sh
@@ -22,7 +22,6 @@ cp __lib__systemd__system__stratux.service work/bin/
 cp __root__stratux-pre-start.sh work/bin/
 cp dump1090/dump1090 work/bin/
 cp -r web work/bin/
-cp image/hostapd.conf work/bin/
 cp image/config.txt work/bin/
 cp image/rtl-sdr-blacklist.conf work/bin/
 cp image/bashrc.txt work/bin/

--- a/selfupdate/makeupdate.sh
+++ b/selfupdate/makeupdate.sh
@@ -22,6 +22,8 @@ cp __lib__systemd__system__stratux.service work/bin/
 cp __root__stratux-pre-start.sh work/bin/
 cp dump1090/dump1090 work/bin/
 cp -r web work/bin/
+cp image/hostapd.conf work/bin/
+cp image/hostapd-edimax.conf work/bin/
 cp image/config.txt work/bin/
 cp image/rtl-sdr-blacklist.conf work/bin/
 cp image/bashrc.txt work/bin/


### PR DESCRIPTION
I have changed the code to use hostapd.user, which contains all the user configurable values and modified stratux-pre-start.sh and stratux-wifi.sh to create /tmp/hostapd.conf on the fly by merging the standard /etc/hostapd/hostapd.conf(or hostapd-edimax.conf if pi2) and /etc/hostapd/hostapd.user to build the /tmp/hostpad.conf.

This allows us to overwrite the /etc/hostapd.conf(or hostapd-edimax.conf) whenever we need and keep any user values.

The changes also will create the hostapd.user file if it does not exist and move all the user configurable settings into it. 

I also changed my hostapd_manager.sh to work on hostapd.user now