### PR TITLE
Gpsd SBAS detection

### DIFF
--- a/main/gpsd.go
+++ b/main/gpsd.go
@@ -28,22 +28,27 @@ func satelliteType(prnId int) uint8 {
 
 func satelliteTypeCode(satType uint8) string {
 	switch satType {
-	case SAT_TYPE_GPS: return "G"
-	case SAT_TYPE_SBAS: return "S"
-	case SAT_TYPE_GLONASS: return "R"
-	case SAT_TYPE_UNKNOWN: return "U"
-	default: return "U"
+	case SAT_TYPE_GPS:
+		return "G"
+	case SAT_TYPE_SBAS:
+		return "S"
+	case SAT_TYPE_GLONASS:
+		return "R"
+	case SAT_TYPE_UNKNOWN:
+		return "U"
+	default:
+		return "U"
 	}
 }
 
 // Caller must protect Satellites with satelliteMutex.
 func isSbasInSolution() bool {
-        for _, satellite := range Satellites {
-                if(satellite.Type == SAT_TYPE_SBAS && satellite.InSolution) {
-                        return true
-                }
-        }
-        return false
+	for _, satellite := range Satellites {
+		if satellite.Type == SAT_TYPE_SBAS && satellite.InSolution {
+			return true
+		}
+	}
+	return false
 }
 
 func processDEVICES(r interface{}) {
@@ -100,7 +105,7 @@ func processTPV(r interface{}) {
 		return
 	}
 
-	if(isSbasInSolution()) {
+	if isSbasInSolution() {
 		mySituation.Quality = 2
 	} else {
 		mySituation.Quality = 1

--- a/main/gpsd.go
+++ b/main/gpsd.go
@@ -122,6 +122,7 @@ func processSKY(r interface{}) {
 		var thisSatellite SatelliteInfo
 		thisSatellite.Type = satelliteType(int(satellite.PRN))
 		thisSatellite.SatelliteID = fmt.Sprint(satelliteTypeCode(thisSatellite.Type), int(satellite.PRN))
+		thisSatellite.Prn = uint8(satellite.PRN)
 		thisSatellite.Azimuth = int16(satellite.Az)
 		thisSatellite.Elevation = int16(satellite.El)
 		thisSatellite.Signal = int8(satellite.Ss)

--- a/main/ry835ai.go
+++ b/main/ry835ai.go
@@ -40,7 +40,7 @@ const (
 )
 
 type SatelliteInfo struct {
-	SatelliteNMEA    uint8     // NMEA ID of the satellite. 1-32 is GPS, 33-54 is SBAS, 65-88 is Glonass.
+	Prn              uint8     // PRN ID of the satellite. 1-32 is GPS, 65-88 is Glonass, 120-138 is SBAS
 	SatelliteID      string    // Formatted code indicating source and PRN code. e.g. S138==WAAS satellite 138, G2==GPS satellites 2
 	Elevation        int16     // Angle above local horizon, -xx to +90
 	Azimuth          int16     // Bearing (degrees true), 0-359
@@ -716,7 +716,7 @@ func processNMEALine(l string) (sentenceUsed bool) {
 					//log.Printf("UBX,03: Satellite %s already seen. Retrieving from 'Satellites'.\n", svStr) // DEBUG
 				} else { // this satellite isn't in the Satellites data structure
 					thisSatellite.SatelliteID = svStr
-					thisSatellite.SatelliteNMEA = uint8(sv)
+					thisSatellite.Prn = uint8(sv)
 					thisSatellite.Type = uint8(svType)
 					//log.Printf("UBX,03: Creating new satellite %s\n", svStr) // DEBUG
 				}
@@ -1125,7 +1125,7 @@ func processNMEALine(l string) (sentenceUsed bool) {
 					//log.Printf("Satellite %s already seen. Retrieving from 'Satellites'.\n", svStr)
 				} else { // this satellite isn't in the Satellites data structure, so create it
 					thisSatellite.SatelliteID = svStr
-					thisSatellite.SatelliteNMEA = uint8(sv)
+					thisSatellite.Prn = uint8(sv)
 					thisSatellite.Type = uint8(svType)
 					//log.Printf("Creating new satellite %s from GSA message\n", svStr) // DEBUG
 				}
@@ -1250,7 +1250,7 @@ func processNMEALine(l string) (sentenceUsed bool) {
 				//log.Printf("Satellite %s already seen. Retrieving from 'Satellites'.\n", svStr) // DEBUG
 			} else { // this satellite isn't in the Satellites data structure, so create it new
 				thisSatellite.SatelliteID = svStr
-				thisSatellite.SatelliteNMEA = uint8(sv)
+				thisSatellite.Prn = uint8(sv)
 				thisSatellite.Type = uint8(svType)
 				//log.Printf("Creating new satellite %s\n", svStr) // DEBUG
 			}

--- a/web/plates/gps.html
+++ b/web/plates/gps.html
@@ -63,16 +63,16 @@
 			<div class="panel-body towers-page">
 				<div class="row">
 					<span class="col-xs-3"><strong>Satellite</strong></span>
-					<!--<span class="col-xs-2 text-right"><strong>NMEA Code</strong></span>-->
+					<!--<span class="col-xs-2 text-right"><strong>PRN Code</strong></span>-->
 					<span class="col-xs-3 text-right"><strong>Elevation</strong></span>
 					<span class="col-xs-3 text-right"><strong>Azimuth</strong></span>
 					<span class="col-xs-3 text-right"><strong>Signal</strong></span>
 				</div>
 
-				<div class="row" ng-repeat="satellite in data_list | orderBy: 'SatelliteNMEA'">
+				<div class="row" ng-repeat="satellite in data_list | orderBy: 'Prn'">
 					<div class="separator"></div>
 					<span class="col-xs-3">{{satellite.SatelliteID}}<span ng-show="satellite.InSolution">&nbsp;&#x2705;</span></span>
-					<!--<span class="col-xs-2 text-right">{{satellite.SatelliteNMEA}}</span>-->
+					<!--<span class="col-xs-2 text-right">{{satellite.Prn}}</span>-->
 					<span class="col-xs-3 text-right">{{satellite.Elevation < -5 ? "---" : satellite.Elevation}}&deg;</span>
 					<span class="col-xs-3 text-right">{{satellite.Azimuth < 0 ? "---" : satellite.Azimuth}}&deg;</span>
 					<span class="col-xs-3 text-right">{{satellite.Signal < 1 ? "---" : satellite.Signal}}<span style="font-size:50%">&nbsp;dB-Hz</span></span>

--- a/web/plates/js/gps.js
+++ b/web/plates/js/gps.js
@@ -129,7 +129,7 @@ function GPSCtrl($rootScope, $scope, $state, $http, $interval) {
 	};
 
 	function setSatellite(obj, new_satellite) {
-		new_satellite.SatelliteNMEA = obj.SatelliteNMEA;
+		new_satellite.Prn = obj.Prn;
 		new_satellite.SatelliteID = obj.SatelliteID;     // Formatted code indicating source and PRN code. e.g. S138==WAAS satellite 138, G2==GPS satellites 2
 		new_satellite.Elevation = obj.Elevation;        // Angle above local horizon, -xx to +90
 		new_satellite.Azimuth = obj.Azimuth;         // Bearing (degrees true), 0-359


### PR DESCRIPTION
* Rename up SatelliteNMEA to Prn, as this field has contained the PRN
* Fix double conversion bug since SKY reports should already be PRN instead of NMEA ID.
* Fix sortation in satellite list by populating the Prn field.
* Set mySituation.Quality to 2 if there is a SBAS PRN satellite in solution

If gpsd is in ublox protocol mode, it will mark the satellite as "in solution" if the PRN is the same as reported by a NAV-SBAS message.  So for ublox device this should be a reliable way to detect WAAS.