### PR TITLE
Gpsd connection management

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -984,6 +984,7 @@ type settings struct {
 	ES_Enabled           bool
 	Ping_Enabled         bool
 	GPS_Enabled          bool
+	GpsdAddress          string
 	NetworkOutputs       []networkConnection
 	SerialOutputs        map[string]serialConnection
 	AHRS_Enabled         bool
@@ -1046,6 +1047,7 @@ func defaultSettings() {
 	globalSettings.UAT_Enabled = true
 	globalSettings.ES_Enabled = true
 	globalSettings.GPS_Enabled = true
+	globalSettings.GpsdAddress = "localhost:2947"
 	//FIXME: Need to change format below.
 	globalSettings.NetworkOutputs = []networkConnection{
 		{Conn: nil, Ip: "", Port: 4000, Capability: NETWORK_GDL90_STANDARD | NETWORK_AHRS_GDL90},

--- a/main/gpsd.go
+++ b/main/gpsd.go
@@ -58,7 +58,9 @@ func isSbasInSolution() bool {
 
 func processDEVICES(r interface{}) {
 	devices := r.(*gpsd.DEVICESReport)
-	log.Printf("DEVICES (%d)", len(devices.Devices))
+	if globalSettings.DEBUG {
+		log.Printf("DEVICES (%d)", len(devices.Devices))
+	}
 	for _, dev := range devices.Devices {
 		log.Printf("  %s %s %x %s %s %i %s %s %i %s %s %i %d %d",
 			dev.Path,
@@ -83,7 +85,9 @@ func processDEVICES(r interface{}) {
 
 func processTPV(r interface{}) {
 	tpv := r.(*gpsd.TPVReport)
-	log.Printf("TPV", tpv.Device, tpv.Mode, tpv.Time, tpv.Tag)
+	if globalSettings.DEBUG {
+		log.Printf("TPV", tpv.Device, tpv.Mode, tpv.Time, tpv.Tag)
+	}
 
 	mySituation.mu_GPS.Lock()
 	satelliteMutex.Lock()
@@ -133,7 +137,9 @@ func processTPV(r interface{}) {
 
 func processSKY(r interface{}) {
 	sky := r.(*gpsd.SKYReport)
-	log.Printf("SKY", sky.Device, sky.Tag)
+	if globalSettings.DEBUG {
+		log.Printf("SKY", sky.Device, sky.Tag)
+	}
 
 	mySituation.mu_GPS.Lock()
 	satelliteMutex.Lock()
@@ -176,7 +182,9 @@ func processSKY(r interface{}) {
 
 func processATT(r interface{}) {
 	att := r.(*gpsd.ATTReport)
-	log.Printf("ATT", att.Device, att.Tag, att.Pitch, att.Roll, att.Heading)
+	if globalSettings.DEBUG {
+		log.Printf("ATT", att.Device, att.Tag, att.Pitch, att.Roll, att.Heading)
+	}
 
 	mySituation.mu_GPS.Lock()
 

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -218,6 +218,12 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 					case "Ping_Enabled":
 						globalSettings.Ping_Enabled = val.(bool)
 					case "GPS_Enabled":
+						switch {
+						case val.(bool) == true && globalSettings.GPS_Enabled == false:
+							connectGpsd(globalSettings.GpsdAddress)
+						case val.(bool) == false && globalSettings.GPS_Enabled == true:
+							disconnectGpsd()
+						}
 						globalSettings.GPS_Enabled = val.(bool)
 					case "AHRS_Enabled":
 						globalSettings.AHRS_Enabled = val.(bool)


### PR DESCRIPTION
* Monitor gpsd connection failures and automatically reconnect
* Add stratux.conf setting to use a different gpsd server.  Advanced users can use a gpsd on another machine.
* User controls connection from management interface using GPS on/off toggle.  If gpsd has no clients, it will disconnect from the device.  Supposedly this can save power on some devices.
* Log individual gpsd messages only in verbose mode.

The requires the latest version of [stratux/go-gpsd](https://github.com/stratux/go-gpsd)