### PR TITLE
Edimax mac check for any RPIs (pi0/2/3)

### DIFF
--- a/image/hostapd_manager.sh
+++ b/image/hostapd_manager.sh
@@ -270,12 +270,18 @@ sleep 0.5
 echo "Killed..."
 echo ""
 echo "ifdown wlan0..."
+echo ""
 ifdown wlan0
 sleep 0.5
+echo "ifdown done..."
+echo ""
 echo "ifup wlan0..."
-echo "Calling Stratux WiFI Start Script(stratux-wifi.sh)..."
+echo "This calls the Stratux WiFI Start Script(stratux-wifi.sh)..."
+echo ""
 ifup wlan0
 sleep 0.5
+echo ""
+echo "ifup done..."
 echo ""
 echo ""
 echo "All systems should be up and running and you should see your new SSID!"

--- a/image/stratux-wifi.sh
+++ b/image/stratux-wifi.sh
@@ -4,27 +4,37 @@
 /usr/bin/killall -9 hostapd hostapd-edimax
 /usr/sbin/service isc-dhcp-server stop
 
+#EDIMAX Mac Addresses from http://www.adminsub.net/mac-address-finder/edimax
+#for logic check all addresses must be lowercase
+edimaxMac=(80:1f:02 74:da:38 00:50:fc 00:1f:1f 00:0e:2e 00:00:b4)
+
 #Assume PI3 settings
 DAEMON_CONF=/etc/hostapd/hostapd.conf
 DAEMON_SBIN=/usr/sbin/hostapd
 
-#User settings for hostapd.conf and hostapd-edimax.conf
+#User configurable settings for hostapd.conf and hostapd-edimax.conf
 DAEMON_USER_PREF=/etc/hostapd/hostapd.user
 
-# Temporary hostapd.conf built by combining
+# Location of temporary hostapd.conf built by combining
 # non-editable /etc/hostapd/hostapd.conf or hostapd-edimax.conf
 # and the user configurable /etc/hostapd/hostapd.conf
 DAEMON_TMP=/tmp/hostapd.conf
 
-# Detect RPi version.
-#  Per http://elinux.org/RPi_HardwareHistory
-EW7811Un=$(lsusb | grep EW-7811Un)
-RPI_REV=`cat /proc/cpuinfo | grep 'Revision' | awk '{print $3}' | sed 's/^1000//'`
-if [ "$RPI_REV" = "a01041" ] || [ "$RPI_REV" = "a21041" ] || [ "$RPI_REV" = "900092" ] || [ "$RPI_REV" = "900093" ] && [ "$EW7811Un" != '' ]; then
- # This is a RPi2B or RPi0 with Edimax USB Wifi dongle.
- DAEMON_CONF=/etc/hostapd/hostapd-edimax.conf
- DAEMON_SBIN=/usr/sbin/hostapd-edimax
+#get the first 3 octets of the MAC(XX:XX:XX) at wlan0
+wlan0mac=$(head -c 8 /sys/class/net/wlan0/address)
+
+# Is there an Edimax Mac Address at wlan0
+if [[ ${edimaxMac[*]} =~ "$wlan0mac" ]]; then
+     DAEMON_CONF=/etc/hostapd/hostapd-edimax.conf
+     DAEMON_SBIN=/usr/sbin//hostapd-edimax
 fi
+
+# I believe a version check of the RPI is not relevant here.
+# Since the use of wlan0 for the Access Point is hard-coded in the hostapd.conf/hostapd-edimax.conf to wlan0 we only need to check wlan0's MAC
+# If the MAC at wlan0 belongs to an Edimax dongle then the edimax driver and config file must be used regardless of RPI version(RPI0/2/3).
+# Note: Another approach is to check for total number of WLANs and then audit each wlans MAC and if available choose a wlan that is not edimax
+# and inject that wlan value when we build the tmp config file.
+# That seems like much more work...
 
 #Make a new hostapd or hostapd-edimax conf file based on logic above
 cat ${DAEMON_USER_PREF} ${DAEMON_CONF} > ${DAEMON_TMP}

--- a/image/stratux-wifi.sh
+++ b/image/stratux-wifi.sh
@@ -29,13 +29,6 @@ if [[ ${edimaxMac[*]} =~ "$wlan0mac" ]]; then
      DAEMON_SBIN=/usr/sbin//hostapd-edimax
 fi
 
-# I believe a version check of the RPI is not relevant here.
-# Since the use of wlan0 for the Access Point is hard-coded in the hostapd.conf/hostapd-edimax.conf to wlan0 we only need to check wlan0's MAC
-# If the MAC at wlan0 belongs to an Edimax dongle then the edimax driver and config file must be used regardless of RPI version(RPI0/2/3).
-# Note: Another approach is to check for total number of WLANs and then audit each wlans MAC and if available choose a wlan that is not edimax
-# and inject that wlan value when we build the tmp config file.
-# That seems like much more work...
-
 #Make a new hostapd or hostapd-edimax conf file based on logic above
 cat ${DAEMON_USER_PREF} ${DAEMON_CONF} > ${DAEMON_TMP}
 


### PR DESCRIPTION
I know we are looking to move away from the PI2 but there is always the possibility of a user losing the onboard wifi by hardware failure.  

I believe this would allow for a user to add an Edimax dongle to the PI3 and still get the system to work. Also, this should work for the PI0 with an edimax dongle

NOTE: On my PIR3 I use an Edimax Dongle as well as the onboard. It is almost a 100% guarantee that the USB-based dongle is detected first, assigning it to WLAN0. I use one WLAN for the Stratux Hotspot and the other to connect to my home/cell wifi for internet access and development/updating. This allows me to access my Stratux via SSH and still have internet access. I know I can use the ETH0 for this also. This is difficult because of the case fan blocking the ETH0 plug and the case being closed most fo the time doensn;t make it any easier .

I believe the previous method of giving weight to the RPI version is not relevant here.  Since the use of wlan0 for the Access Point is hard-coded in the hostapd.conf/hostapd-edimax.conf to wlan0 we only need to check wlan0's MAC and compare to known MACs for Edimax dongles. 

I am using http://www.adminsub.net/mac-address-finder/edimax as the list of possible MAC address ranges

If the MAC at wlan0 belongs to an Edimax dongle then the edimax driver and config file must be used regardless of RPI version(RPI0/2/3).

Note: Another approach is to check the MAC at wlan0 and if it is an EDIMAX MAC then see if there is another WLAN available without an EDIMAX MAC and use it by dynamically modifying the configuration files. But if this fails... we are back to needing to use the EDIMAX drivers... SO...

That seems like much more work to get to the same place...