### PR TITLE
Add ability to set static ip from web ui when in dev mode

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1034,6 +1034,7 @@ type settings struct {
 	OwnshipModeS         string
 	WatchList            string
 	DeveloperMode        bool
+	StaticIps            []string
 }
 
 type status struct {
@@ -1096,6 +1097,7 @@ func defaultSettings() {
 	globalSettings.ReplayLog = false //TODO: 'true' for debug builds.
 	globalSettings.OwnshipModeS = "F00000"
 	globalSettings.DeveloperMode = false
+	globalSettings.StaticIps = make([]string, 0)
 }
 
 func readSettings() {

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"syscall"
 	"text/template"
@@ -319,6 +320,26 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 							continue
 						}
 						globalSettings.OwnshipModeS = fmt.Sprintf("%02X%02X%02X", hexn[0], hexn[1], hexn[2])
+					case "StaticIps":
+						ipsStr := val.(string)
+						ips := strings.Split(ipsStr, " ")
+						if ipsStr == "" {
+							ips = make([]string, 0)
+						}
+
+						re, _ := regexp.Compile(`^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$`)
+						err := ""
+						for _, ip := range ips {
+							// Verify IP format
+							if !re.MatchString(ip) {
+								err = err + "Invalid IP: " + ip + ". "
+							}
+						}
+						if err  != "" {
+							log.Printf("handleSettingsSetRequest:StaticIps: %s\n", err)
+							continue
+						}
+						globalSettings.StaticIps = ips
 					default:
 						log.Printf("handleSettingsSetRequest:json: unrecognized key:%s\n", key)
 					}

--- a/main/network.go
+++ b/main/network.go
@@ -115,6 +115,14 @@ func getDHCPLeases() (map[string]string, error) {
 		}
 	}
 
+        // Add IP's set through the settings page
+	if globalSettings.StaticIps != nil {
+		for _, ip := range globalSettings.StaticIps {
+			ret[ip] = ""
+		}
+	}
+
+
 	// Added the ability to have static IP hosts stored in /etc/stratux-static-hosts.conf
 
 	dat2, err := ioutil.ReadFile(extra_hosts_file)

--- a/notes/app-vendor-integration.md
+++ b/notes/app-vendor-integration.md
@@ -134,7 +134,9 @@ Stratux makes available a webserver to retrieve statistics which may be useful t
   "ReplayLog": true,
   "PPM": 0,
   "OwnshipModeS": "F00000",
-  "WatchList": ""
+  "WatchList": "",
+  "DeveloperMode": false,
+  "StaticIps": []
 }
 ```
 * `http://192.168.10.1/setSettings` - set device settings. Use an HTTP POST of JSON content in the format given above - posting only the fields containing the settings to be modified.

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -33,6 +33,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		$scope.WatchList = settings.WatchList;
 		$scope.OwnshipModeS = settings.OwnshipModeS;
 		$scope.DeveloperMode = settings.DeveloperMode;
+		$scope.StaticIps = settings.StaticIps;
 	}
 
 	function getSettings() {
@@ -126,6 +127,15 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 			settings["OwnshipModeS"] = $scope.OwnshipModeS.toUpperCase();
 			newsettings = {
 				"OwnshipModeS": $scope.OwnshipModeS.toUpperCase()
+			};
+			// console.log(angular.toJson(newsettings));
+			setSettings(angular.toJson(newsettings));
+		}
+	};
+	$scope.updatestaticips = function () {
+		if ($scope.StaticIps !== settings.StaticIps) {
+			newsettings = {
+				"StaticIps": $scope.StaticIps === undefined? "" : $scope.StaticIps.join(' ')
 			};
 			// console.log(angular.toJson(newsettings));
 			setSettings(angular.toJson(newsettings));

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -135,7 +135,12 @@
 			<div class="panel-heading">Developer Options</div>
 			<div class="panel-body">
 				<div class="col-xs-12">
-                <p>Coming soon</p>
+					<div class="form-group reset-flow">
+						<label class="control-label col-xs-5">Static IPs</label>
+						<form name="staticipForm" ng-submit="updatestaticips()" novalidate>
+							<input class="col-xs-7" type="string" required ng-model="StaticIps" ng-list=" " ng-trim="false" placeholder="space-delimited ip's to send network data" ng-blur="updatestaticips()" />
+						</form>
+					</div>
 				</div>
 			</div>
 		</div>
@@ -143,8 +148,7 @@
 </div>
 
 
-<!--
-<div class="col-sm-12">
+<div class="col-sm-12" ng-show="DeveloperMode" >
 	<div class="panel panel-default">
 		<div class="panel-heading">Raw Configuration</div>
 		<div class="panel-body">
@@ -153,7 +157,6 @@
 		</div>
 	</div>
 </div>
--->
  
 <div class="col-sm-12">
  	<h3 ui-if="rebooting" ui-state="rebooting">Stratux is rebooting.  You may need to reconnect WiFi once it reboots.</h3>


### PR DESCRIPTION
1) Added the ability to add a space separated list of IP's that will be sent network data for use when testing while connected to a network other than the Raspberry PI Network.  I did see that a file could be created that contained those IP's but this seems easier.  (only visible when DeveloperMode is enabled)

2) Removed Windows characters from settings.js,  (didn't want them to be inconsistent and was editing on the Raspberry PI not on Windows. 

3) Display Raw Configuration when DeveloperMode is set. 