### PR TITLE
Remove hardcoded alert flag on traffic report and replace with simple…

### DIFF
--- a/main/traffic.go
+++ b/main/traffic.go
@@ -97,7 +97,6 @@ type TrafficInfo struct {
 	Speed_valid         bool      // set when speed report received.
 	Vvel                int16     // feet per minute
 	Timestamp           time.Time // timestamp of traffic message, UTC
-	PriorityStatus      uint8     // Emergency or priority code as defined in GDL90 spec, DO-260B (Type 28 msg) and DO-282B
 
 	// Parameters starting at 'Age' are calculated from last message receipt on each call of sendTrafficUpdates().
 	// Mode S transmits position and track in separate messages, and altitude can also be
@@ -111,9 +110,9 @@ type TrafficInfo struct {
 	Last_speed           time.Time // Time of last velocity and track update (stratuxClock).
 	Last_source          uint8     // Last frequency on which this target was received.
 	ExtrapolatedPosition bool      //TODO: True if Stratux is "coasting" the target from last known position.
+	BearingDist_valid    bool      // set when bearing and distance information is valid  
 	Bearing              float64   // Bearing in degrees true to traffic from ownship, if it can be calculated.
 	Distance             float64   // Distance to traffic from ownship, if it can be calculated.
-	//FIXME: Some indicator that Bearing and Distance are valid, since they aren't always available.
 	//FIXME: Rename variables for consistency, especially "Last_".
 }
 
@@ -191,6 +190,7 @@ func sendTrafficUpdates() {
 			dist, bearing := distance(float64(mySituation.Lat), float64(mySituation.Lng), float64(ti.Lat), float64(ti.Lng))
 			ti.Distance = dist
 			ti.Bearing = bearing
+			ti.BearingDist_valid = true
 		}
 		ti.Age = stratuxClock.Since(ti.Last_seen).Seconds()
 		ti.AgeLastAlt = stratuxClock.Since(ti.Last_alt).Seconds()
@@ -251,13 +251,32 @@ func registerTrafficUpdate(ti TrafficInfo) {
 	trafficUpdate.SendJSON(ti)
 }
 
+func isTrafficAlertable(ti TrafficInfo) bool {
+	// Set alert bit if possible and traffic is within some threshold
+	// TODO: Could be more intelligent, taking into account headings etc.
+	if ti.BearingDist_valid &&
+	   ti.Distance < 3704 { // TODO: Maybe make configurable?
+	   return true
+	}
+	
+	return false
+}
+
+
 func makeTrafficReportMsg(ti TrafficInfo) []byte {
 	msg := make([]byte, 28)
 	// See p.16.
 	msg[0] = 0x14 // Message type "Traffic Report".
 
-	msg[1] = 0x10 | ti.Addr_type // Alert status, address type.
-
+    // Address type
+	msg[1] = ti.Addr_type
+	
+	// Set alert if needed
+	if isTrafficAlertable(ti) {
+	    // Set the alert bit.  See pg. 18 of GDL90 ICD
+	    msg[1] |= 0x10
+	}
+	
 	// ICAO Address.
 	msg[2] = byte((ti.Icao_addr & 0x00FF0000) >> 16)
 	msg[3] = byte((ti.Icao_addr & 0x0000FF00) >> 8)
@@ -349,17 +368,9 @@ func makeTrafficReportMsg(ti TrafficInfo) []byte {
 		msg[19+i] = c
 	}
 
-	//msg[27] is priority / emergency status per GDL90 spec (DO260B and DO282B are same codes)
-	msg[27] = ti.PriorityStatus << 4
-
 	return prepareMessage(msg)
 }
 
-// parseDownlinkReport decodes a UAT downlink message to extract identity, state vector, and mode status data.
-// Decoded data is used to update a TrafficInfo object, keyed to the 24-bit ICAO code contained in the
-// downlink message.
-// Inputs are a checksum-verified hex string corresponding to the 18 or 34-byte UAT
-// message, and an int representing UAT signal amplitude (0-1000).
 func parseDownlinkReport(s string, signalLevel int) {
 
 	var ti TrafficInfo
@@ -394,110 +405,41 @@ func parseDownlinkReport(s string, signalLevel int) {
 
 	ti.Addr_type = addr_type
 
-	var uat_version byte // sent as part of MS element, byte 24
+	// Parse tail number, if available.
+	if msg_type == 1 || msg_type == 3 { // Need "MS" portion of message.
+		base40_alphabet := string("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ  ..")
+		tail := ""
 
-	// Extract parameters from Mode Status elements, if available.
-	if msg_type == 1 || msg_type == 3 {
+		v := (uint16(frame[17]) << 8) | uint16(frame[18])
+		tail += string(base40_alphabet[(v/40)%40])
+		tail += string(base40_alphabet[v%40])
+		v = (uint16(frame[19]) << 8) | uint16(frame[20])
+		tail += string(base40_alphabet[(v/1600)%40])
+		tail += string(base40_alphabet[(v/40)%40])
+		tail += string(base40_alphabet[v%40])
+		v = (uint16(frame[21]) << 8) | uint16(frame[22])
+		tail += string(base40_alphabet[(v/1600)%40])
+		tail += string(base40_alphabet[(v/40)%40])
+		tail += string(base40_alphabet[v%40])
 
-		// Determine UAT message version. This is needed for some capability decoding and is useful for debugging.
-		uat_version = (frame[23] >> 2) & 0x07
-
-		// Extract emitter category.
-		v := (uint16(frame[17]) << 8) | (uint16(frame[18]))
-		ti.Emitter_category = uint8((v / 1600) % 40)
-
-		// Decode callsign or Flight Plan ID (i.e. squawk code)
-		// If the CSID bit (byte 27, bit 7) is set to 1, all eight characters
-		// encoded in bytes 18-23 represent callsign.
-		// If the CSID bit is set to 0, the first four characters encoded in bytes 18-23
-		// represent the Mode A squawk code.
-
-		csid := (frame[26] >> 1) & 0x01
-
-		if csid == 1 { // decode as callsign
-			base40_alphabet := string("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ  ..")
-			tail := ""
-
-			v := (uint16(frame[17]) << 8) | uint16(frame[18])
-			tail += string(base40_alphabet[(v/40)%40])
-			tail += string(base40_alphabet[v%40])
-			v = (uint16(frame[19]) << 8) | uint16(frame[20])
-			tail += string(base40_alphabet[(v/1600)%40])
-			tail += string(base40_alphabet[(v/40)%40])
-			tail += string(base40_alphabet[v%40])
-			v = (uint16(frame[21]) << 8) | uint16(frame[22])
-			tail += string(base40_alphabet[(v/1600)%40])
-			tail += string(base40_alphabet[(v/40)%40])
-			tail += string(base40_alphabet[v%40])
-			tail = strings.Trim(tail, " ")
-			ti.Tail = tail
-
-		} else if uat_version >= 2 { // decode as Mode 3/A code, if UAT version is at least 2
-			v := (uint16(frame[17]) << 8) | uint16(frame[18])
-			squawk_a := (v / 40) % 40
-			squawk_b := v % 40
-			v = (uint16(frame[19]) << 8) | uint16(frame[20])
-			squawk_c := (v / 1600) % 40
-			squawk_d := (v / 40) % 40
-			squawk := 1000*squawk_a + 100*squawk_b + 10*squawk_c + squawk_d
-			ti.Squawk = int(squawk)
-		}
-
-		ti.NACp = int((frame[25] >> 4) & 0x0F)
-		ti.PriorityStatus = (frame[23] >> 5) & 0x07
-
-		// Following section is future-use for debugging and / or additional status info on UAT traffic. Message parsing needs testing.
-
-		if globalSettings.DEBUG {
-			//declaration for mode status flags -- parse for debug logging
-			var status_sil byte
-			//var status_transmit_mso byte
-			var status_sda byte
-			var status_nacv byte
-			//var status_nicbaro byte
-			//var status_sil_supp byte
-			//var status_geom_vert_acc byte
-			//var status_sa_flag byte
-			var capability_uat_in bool
-			var capability_1090_in bool
-			//var capability_tcas bool
-			//var capability_cdti bool
-			//var opmode_tcas_active bool
-			//var opmode_ident_active bool
-			//var opmode_rec_atc_serv bool
-
-			// these are present in v1 and v2 messages
-			status_sil = frame[23] & 0x03
-			//status_transmit_mso = frame[24] >> 2
-			status_nacv = (frame[25] >> 1) & 0x07
-			//status_nicbaro = frame[25] & 0x01
-
-			// other status and capability bits are different between v1 and v2
-			if uat_version == 2 {
-				status_sda = frame[24] & 0x03
-				capability_uat_in = (frame[26] >> 7) != 0
-				capability_1090_in = ((frame[26] >> 6) & 0x01) != 0
-				//capability_tcas = ((frame[26] >> 5) & 0x01) != 0
-				//opmode_tcas_active = ((frame[26] >> 4) & 0x01) != 0
-				//opmode_ident_active = ((frame[26] >> 3) & 0x01) != 0
-				//opmode_rec_atc_serv = ((frame[26] >> 2) & 0x01) != 0
-				//status_sil_supp = frame[26] & 0x01
-				//status_geom_vert_acc = (frame[27] >> 6) & 0x03
-				//status_sa_flag = (frame[27] >> 5) & 0x01
-
-			} else if uat_version == 1 {
-				//capability_cdti = (frame[26] >> 7) != 0
-				//capability_tcas = ((frame[26] >> 6) & 0x01) != 0
-				//opmode_tcas_active = ((frame[26] >> 5) & 0x01) != 0
-				//opmode_ident_active = ((frame[26] >> 4) & 0x01) != 0
-				//opmode_rec_atc_serv = ((frame[26] >> 3) & 0x01) != 0
-			}
-
-			log.Printf("Supplemental UAT Mode Status for %06X: Version = %d; SIL = %d; SDA = %d; NACv = %d; 978 In = %v; 1090 In = %v\n", icao_addr, uat_version, status_sil, status_sda, status_nacv, capability_uat_in, capability_1090_in)
-		}
+		tail = strings.Trim(tail, " ")
+		ti.Tail = tail
 	}
 
+	// Extract emitter category.
+	if msg_type == 1 || msg_type == 3 {
+		v := (uint16(frame[17]) << 8) | (uint16(frame[18]))
+		ti.Emitter_category = uint8((v / 1600) % 40)
+	}
+
+	// OK.
+	//	fmt.Printf("%d, %d, %06X\n", msg_type, ti.Addr_type, ti.Icao_addr)
+
 	ti.NIC = int(frame[11] & 0x0F)
+
+	if (msg_type == 1) || (msg_type == 3) { // Since NACp is passed with normal UATreports, no need to use our ES hack.
+		ti.NACp = int((frame[25] >> 4) & 0x0F)
+	}
 
 	var power float64
 	if signalLevel > 0 {
@@ -568,6 +510,7 @@ func parseDownlinkReport(s string, signalLevel int) {
 		ti.Lng = lng
 		if isGPSValid() {
 			ti.Distance, ti.Bearing = distance(float64(mySituation.Lat), float64(mySituation.Lng), float64(ti.Lat), float64(ti.Lng))
+			ti.BearingDist_valid = true
 		}
 		ti.Last_seen = stratuxClock.Time
 		ti.ExtrapolatedPosition = false
@@ -627,7 +570,7 @@ func parseDownlinkReport(s string, signalLevel int) {
 			}
 		}
 		if ns_vel_valid && ew_vel_valid {
-			if ns_vel != 0 || ew_vel != 0 {
+			if ns_vel != 0 && ew_vel != 0 {
 				//TODO: Track type
 				track = uint16((360 + 90 - (int16(math.Atan2(float64(ns_vel), float64(ew_vel)) * 180 / math.Pi))) % 360)
 			}
@@ -668,6 +611,7 @@ func parseDownlinkReport(s string, signalLevel int) {
 		ti.Last_speed = stratuxClock.Time
 	}
 
+	//OK.
 	//	fmt.Printf("ns_vel %d, ew_vel %d, track %d, speed_valid %t, speed %d, vvel_geo %t, vvel %d\n", ns_vel, ew_vel, track, speed_valid, speed, vvel_geo, vvel)
 
 	/*
@@ -681,6 +625,7 @@ func parseDownlinkReport(s string, signalLevel int) {
 		}
 	*/
 
+	//OK.
 	//	fmt.Printf("tisb_site_id %d, utc_coupled %t\n", tisb_site_id, utc_coupled)
 
 	ti.Timestamp = time.Now()
@@ -849,6 +794,7 @@ func esListen() {
 					ti.Lng = lng
 					if isGPSValid() {
 						ti.Distance, ti.Bearing = distance(float64(mySituation.Lat), float64(mySituation.Lng), float64(ti.Lat), float64(ti.Lng))
+						ti.BearingDist_valid = true
 					}
 					ti.Position_valid = true
 					ti.ExtrapolatedPosition = false
@@ -1083,6 +1029,7 @@ func updateDemoTraffic(icao uint32, tail string, relAlt float32, gs float64, off
 	ti.Lng = float32(lng + traffRelLng)
 
 	ti.Distance, ti.Bearing = distance(float64(lat), float64(lng), float64(ti.Lat), float64(ti.Lng))
+	ti.BearingDist_valid = true
 
 	ti.Position_valid = true
 	ti.ExtrapolatedPosition = false


### PR DESCRIPTION
… logic to set it only if a target is within 2nm.   This addresses issue #580 and has been flight tested with Avidyne IFD equipement.