### PR TITLE
fixed a bug that NEO-M8 will use 1 Hz update rate when Galileo is enabled. Slightly reduced Galileo's maximum tracking channel.

### DIFF
--- a/main/gps.go
+++ b/main/gps.go
@@ -287,8 +287,8 @@ func initGPSSerial() bool {
 		if (globalStatus.GPS_detected_type == GPS_TYPE_UBX8) || (globalStatus.GPS_detected_type == GPS_TYPE_UART) { // assume that any GPS connected to serial GPIO is ublox8 (RY835/6AI)
 			//log.Printf("UBX8 device detected on USB, or GPS serial connection in use. Attempting GLONASS and Galelio configuration.\n")
 			glonass = []byte{0x06, 0x08, 0x0E, 0x00, 0x01, 0x00, 0x01, 0x01} // this enables GLONASS with 8-14 tracking channels
-			galileo = []byte{0x02, 0x04, 0x08, 0x00, 0x01, 0x00, 0x01, 0x01} // this enables Galileo with 4-8 tracking channels
-			updatespeed = []byte{0x06, 0x00, 0xF4, 0x01, 0x01, 0x00}         // Nav speed 2Hz
+			galileo = []byte{0x02, 0x04, 0x05, 0x00, 0x01, 0x00, 0x01, 0x01} // this enables Galileo with 4-5 tracking channels
+			updatespeed = []byte{0xF4, 0x01, 0x01, 0x00, 0x01, 0x00}         // Nav speed 2 Hz for enabling Galileo
 		}
 		cfgGnss = append(cfgGnss, gps...)
 		cfgGnss = append(cfgGnss, sbas...)


### PR DESCRIPTION
The current setting we use is incorrect for a 2 Hz configuration. The update interval is set to 166 Hz and sample for calculation is set to 500 and is outside of the chip's capability. This causes NEO-M8 to fallback to the default 1 Hz update rate and is not really desirable.

This PR changes the `updatespeed` array to contains the correct configuration payload that enables a 2 Hz update rate.

This PR also reduces the maximum tracking channel of Galileo from 8 to 5 as there are currently only 11 operational satellite inside the Galileo system and it is not likely to observe more than ~5 satellites at a given point on earth. With this change we free up 3 more tracking channels for GPS/GLONASS/SBAS.

Also I noticed that enabling Galileo negatively affects the tracking accuracy of GPS/GLONASS when Galileo is not being used. Before enabling Galileo, with 6 GPS/GLONASS satellite tracked, I can get 10-15mm location accuracy. After enabling Galileo, with 6 GPS/GLONASS satellite tracked, I can only get 20-30m of location accuracy. This trend is pretty consistent during multiple runs at the same location and time. I don't know the cause of this but most likely a combine of less tracking channel for GPS/GLONASS and little Galileo satellite available for tracking. Not even to mention that additional 4 Galileo tracking caused us to lose 80% of location update rate globally.

Maybe we should rethink about turning on Galileo by default. An option inside Settings is certainly desirable.

![image](https://cloud.githubusercontent.com/assets/1131072/25499666/00109514-2b41-11e7-97ef-e3f676a9b49e.png)