### PR TITLE
Support Raspberry Pi 3B with newer kernels

### DIFF
--- a/main/gps.go
+++ b/main/gps.go
@@ -20,9 +20,10 @@ import (
 
 	"bufio"
 
-	"github.com/kidoman/embd"
-	_ "github.com/kidoman/embd/host/all"
-	"github.com/kidoman/embd/sensor/bmp180"
+	// use fork of embd to support RPi3B until kidoman merges long-oustanding PRs.
+	"github.com/lukepalmer/embd"
+	_ "github.com/lukepalmer/embd/host/all"
+	"github.com/lukepalmer/embd/sensor/bmp180"
 	"github.com/tarm/serial"
 
 	"os"

--- a/test/bmp180_read.go
+++ b/test/bmp180_read.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/kidoman/embd"
-	_ "github.com/kidoman/embd/host/all"
-	"github.com/kidoman/embd/sensor/bmp180"
+	// use fork of embd to support RPi3B until kidoman merges long-oustanding PRs.
+	"github.com/lukepalmer/embd"
+	_ "github.com/lukepalmer/embd/host/all"
+	"github.com/lukepalmer/embd/sensor/bmp180"
 )
 
 var i2cbus embd.I2CBus


### PR DESCRIPTION
Building with current raspbian and HEAD, stratux will not start on a Raspberry Pi 3B due to a problem in embd that causes hardware to not be recognized.

kidoman/embd#79 gets things working, but @kidoman has been busy with a startup and has not merged PRs in a very long time.

Because go get does not know how to pull from branches, to get things working again I merged this into a fork and referenced that from within stratux. Hopefully if embd sees some love in the future we can undo this change. 