### PR TITLE
Added toggle switch for Galileo tracking. Slightly reduced number Galileo tracking channels to ensure tracking performance of mature GNSS systems.

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1043,6 +1043,7 @@ type settings struct {
 	WatchList            string
 	DeveloperMode        bool
 	StaticIps            []string
+	Galileo_Enabled      bool
 }
 
 type status struct {
@@ -1106,6 +1107,7 @@ func defaultSettings() {
 	globalSettings.OwnshipModeS = "F00000"
 	globalSettings.DeveloperMode = false
 	globalSettings.StaticIps = make([]string, 0)
+	globalSettings.Galileo_Enabled = false
 }
 
 func readSettings() {

--- a/main/gps.go
+++ b/main/gps.go
@@ -287,8 +287,15 @@ func initGPSSerial() bool {
 		if (globalStatus.GPS_detected_type == GPS_TYPE_UBX8) || (globalStatus.GPS_detected_type == GPS_TYPE_UART) { // assume that any GPS connected to serial GPIO is ublox8 (RY835/6AI)
 			//log.Printf("UBX8 device detected on USB, or GPS serial connection in use. Attempting GLONASS and Galelio configuration.\n")
 			glonass = []byte{0x06, 0x08, 0x0E, 0x00, 0x01, 0x00, 0x01, 0x01} // this enables GLONASS with 8-14 tracking channels
-			galileo = []byte{0x02, 0x04, 0x08, 0x00, 0x01, 0x00, 0x01, 0x01} // this enables Galileo with 4-8 tracking channels
-			updatespeed = []byte{0x06, 0x00, 0xF4, 0x01, 0x01, 0x00}         // Nav speed 2Hz
+
+			if globalSettings.Galileo_Enabled {
+				galileo = []byte{0x02, 0x04, 0x05, 0x00, 0x01, 0x00, 0x01, 0x01} // this enables Galileo with 4-5 tracking channels
+				updatespeed = []byte{0xF4, 0x01, 0x01, 0x00, 0x01, 0x00}         // Nav speed 2Hz
+
+				if globalSettings.DEBUG {
+					log.Printf("Enabling Galileo tracking, nav rate capped at 2 Hz")
+				}
+			}
 		}
 		cfgGnss = append(cfgGnss, gps...)
 		cfgGnss = append(cfgGnss, sbas...)

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -340,6 +340,8 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 							continue
 						}
 						globalSettings.StaticIps = ips
+					case "Galileo_Enabled":
+						globalSettings.Galileo_Enabled = val.(bool)
 					default:
 						log.Printf("handleSettingsSetRequest:json: unrecognized key:%s\n", key)
 					}

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -6,7 +6,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 
 	$scope.$parent.helppage = 'plates/settings-help.html';
 
-	var toggles = ['UAT_Enabled', 'ES_Enabled', 'Ping_Enabled', 'GPS_Enabled', 'DisplayTrafficSource', 'DEBUG', 'ReplayLog']; 
+	var toggles = ['UAT_Enabled', 'ES_Enabled', 'Ping_Enabled', 'GPS_Enabled', 'DisplayTrafficSource', 'DEBUG', 'ReplayLog', 'Galileo_Enabled']; 
 	var settings = {};
 	for (i = 0; i < toggles.length; i++) {
 		settings[toggles[i]] = undefined;
@@ -34,6 +34,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		$scope.OwnshipModeS = settings.OwnshipModeS;
 		$scope.DeveloperMode = settings.DeveloperMode;
 		$scope.StaticIps = settings.StaticIps;
+ 		$scope.Galileo_Enabled = settings.Galileo_Enabled;
 	}
 
 	function getSettings() {

--- a/web/plates/settings-help.html
+++ b/web/plates/settings-help.html
@@ -5,6 +5,10 @@
 	<p class="text-warning">NOTE: Only hardware toggled on here, will appear on the
 		<stron>Status</stron> page.</p>
 
+	<p>Galileo tracking is only meaningful for devices running Ublox 8 chipset with firmware 3.01. Ublox 7
+	or Ublox 8 devices with older firmware will get no benefit but reduced nav rate (2Hz) when enabled.
+	Changing this setting requires a complete power cycle of the GPS receiver (Shutdown - Unplug - Replug) to take effect.</p>
+
 	<p>The <strong>Diagnostics</strong> section helps with debugging and communicating with the Stratux project contributors via GitHub and the reddit subgroup.
 		<ul class="list-simple">
 			<li>Toggling <strong>Traffic Source</strong> adds text for traffic targets within your navigation application. Traffic received via UAT will display <code>u</code> while traffic received via 1090 will display <code>e</code>.</li>

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -28,6 +28,12 @@
 						<ui-switch ng-model='GPS_Enabled' settings-change></ui-switch>
 					</div>
 				</div>
+				<div class="form-group">
+					<label class="control-label col-xs-7">Galileo (see HELP)</label>
+					<div class="col-xs-5">
+						<ui-switch ng-model='Galileo_Enabled' settings-change></ui-switch>
+					</div>
+				</div>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
I attempted to do a hot reinitialization of the GPS receiver by setting `globalStatus.GPS_connected` to `false` and force `initGPSSerial` to be called. But despite new configs being sent, those settings are not taking effect until the GPS receiver was power cycled (for GPS connected with GPIO, that requires to pull the power plug and re-connect). 

Anyway, after a power cycle, the settings will take effect correctly.

Leaving Galileo to OFF by default for reasons phrased inside #589.

Supersedes #589.

Tested with my GPIO RY836AI build and works great.

<img width="556" alt="screen shot 2017-05-13 at 9 30 32 pm" src="https://cloud.githubusercontent.com/assets/1131072/26031320/72f6c956-3823-11e7-8a1e-82ad059e5fbf.png">
