### PR TITLE
Removed Galileo nav rate change. Slightly reduced Galileo's maximum tracking channel.

### DIFF
--- a/main/gps.go
+++ b/main/gps.go
@@ -288,7 +288,6 @@ func initGPSSerial() bool {
 			//log.Printf("UBX8 device detected on USB, or GPS serial connection in use. Attempting GLONASS and Galelio configuration.\n")
 			glonass = []byte{0x06, 0x08, 0x0E, 0x00, 0x01, 0x00, 0x01, 0x01} // this enables GLONASS with 8-14 tracking channels
 			galileo = []byte{0x02, 0x04, 0x05, 0x00, 0x01, 0x00, 0x01, 0x01} // this enables Galileo with 4-5 tracking channels
-			updatespeed = []byte{0xF4, 0x01, 0x01, 0x00, 0x01, 0x00}         // Nav speed 2 Hz for enabling Galileo
 		}
 		cfgGnss = append(cfgGnss, gps...)
 		cfgGnss = append(cfgGnss, sbas...)

--- a/main/gps.go
+++ b/main/gps.go
@@ -287,8 +287,8 @@ func initGPSSerial() bool {
 		if (globalStatus.GPS_detected_type == GPS_TYPE_UBX8) || (globalStatus.GPS_detected_type == GPS_TYPE_UART) { // assume that any GPS connected to serial GPIO is ublox8 (RY835/6AI)
 			//log.Printf("UBX8 device detected on USB, or GPS serial connection in use. Attempting GLONASS and Galelio configuration.\n")
 			glonass = []byte{0x06, 0x08, 0x0E, 0x00, 0x01, 0x00, 0x01, 0x01} // this enables GLONASS with 8-14 tracking channels
-			galileo = []byte{0x02, 0x04, 0x08, 0x00, 0x01, 0x00, 0x01, 0x01} // this enables Galileo with 4-8 tracking channels
-			updatespeed = []byte{0x06, 0x00, 0xF4, 0x01, 0x01, 0x00}         // Nav speed 2Hz
+			galileo = []byte{0x02, 0x04, 0x05, 0x00, 0x01, 0x00, 0x01, 0x01} // this enables Galileo with 4-5 tracking channels
+			updatespeed = []byte{0xF4, 0x01, 0x01, 0x00, 0x01, 0x00}         // Nav speed 2 Hz for enabling Galileo
 		}
 		cfgGnss = append(cfgGnss, gps...)
 		cfgGnss = append(cfgGnss, sbas...)


### PR DESCRIPTION
The current setting we use is incorrect for a 2 Hz configuration. The update interval is set to 166 Hz and sample for calculation is set to 500 and is outside of the chip's capability. This causes NEO-M8 to fallback to the default 1 Hz update rate and is not really desirable.

According to [answer from Ublox forum](https://forum.u-blox.com/index.php?qa=2342&qa_1=enable-galileo-navigation-rate-need-where-find-rate-change&show=2347#a2347), we actually do not need to tune down the nav rate when enabling Galileo at all as the chip will automatically scale down as necessary. I have been able to confirm this behavior, that is, the nav rate only goes down when Galileo is being tracked and stays at 10 Hz when no Galileo satellite was used in the calculation (and appears to scale down linearly as the number of Galileo satellite tracked goes up). Adding a toggle switch for Galileo is also no longer necessary as older chip user should receive no negative impact from enabling Galileo.

This PR also reduces the maximum tracking channel of Galileo from 8 to 5 as there are currently only 11 operational satellite inside the Galileo system and it is not likely to observe more than ~5 satellites at a given point on earth. With this change we free up 3 more tracking channels for GPS/GLONASS/SBAS.

**Before:**
<img width="556" alt="screen shot 2017-05-13 at 9 30 32 pm" src="https://cloud.githubusercontent.com/assets/1131072/26031320/72f6c956-3823-11e7-8a1e-82ad059e5fbf.png">

**After:**
<img width="538" alt="screen shot 2017-05-13 at 9 54 43 pm" src="https://cloud.githubusercontent.com/assets/1131072/26031643/1540c61a-3830-11e7-8825-381ee687fc06.png">
