### PR TITLE
Added nav rate display and Galileo nav rate change for AHRS branch.

### DIFF
--- a/main/gps.go
+++ b/main/gps.go
@@ -1928,7 +1928,10 @@ func gpsAttitudeSender() {
 	timer := time.NewTicker(100 * time.Millisecond) // ~10Hz update.
 	for {
 		<-timer.C
-		myGPSPerfStats = make([]gpsPerfStats, 0) // reinitialize statistics on disconnect / reconnect
+		if !(globalStatus.GPS_connected || globalStatus.IMUConnected) {
+			myGPSPerfStats = make([]gpsPerfStats, 0) // reinitialize statistics on disconnect / reconnect
+		}
+
 		for !(globalSettings.IMU_Sensor_Enabled && globalStatus.IMUConnected) && (globalSettings.GPS_Enabled && globalStatus.GPS_connected) {
 			<-timer.C
 

--- a/main/gps.go
+++ b/main/gps.go
@@ -293,7 +293,6 @@ func initGPSSerial() bool {
 			//log.Printf("UBX8 device detected on USB, or GPS serial connection in use. Attempting GLONASS and Galelio configuration.\n")
 			glonass = []byte{0x06, 0x08, 0x0E, 0x00, 0x01, 0x00, 0x01, 0x01} // this enables GLONASS with 8-14 tracking channels
 			galileo = []byte{0x02, 0x04, 0x05, 0x00, 0x01, 0x00, 0x01, 0x01} // this enables Galileo with 4-5 tracking channels
-			updatespeed = []byte{0xF4, 0x01, 0x01, 0x00, 0x01, 0x00}         // Nav speed 2 Hz for enabling Galileo
 		}
 		cfgGnss = append(cfgGnss, gps...)
 		cfgGnss = append(cfgGnss, sbas...)

--- a/main/gps.go
+++ b/main/gps.go
@@ -534,7 +534,7 @@ func calcGPSAttitude() bool {
 	// If all of the bounds checks pass, begin processing the GPS data.
 
 	// local variables
-	var headingAvg, dh, v_x, v_z, a_c, omega, slope, intercept, dt_avg float64
+	var headingAvg, dh, v_x, v_z, a_c, omega, slope, intercept float64
 	var tempHdg, tempHdgUnwrapped, tempHdgTime, tempSpeed, tempVV, tempSpeedTime, tempRegWeights []float64 // temporary arrays for regression calculation
 	var valid bool
 	var lengthHeading, lengthSpeed int
@@ -814,7 +814,8 @@ func calculateNavRate() float64 {
 		}
 	}
 
-	dt_avg, valid = mean(tempSpeedTime)
+	var halfwidth float64
+	dt_avg, valid := mean(tempSpeedTime)
 	if valid && dt_avg > 0 {
 		if globalSettings.DEBUG {
 			log.Printf("GPS attitude: Average delta time is %.2f s (%.1f Hz)\n", dt_avg, 1/dt_avg)

--- a/main/gps.go
+++ b/main/gps.go
@@ -1054,10 +1054,6 @@ func processNMEALine(l string) (sentenceUsed bool) {
 				mySituation.muGPSPerformance.Unlock()
 			}
 
-			if globalSettings.IMU_Sensor_Enabled && globalStatus.IMUConnected {
-				calculateNavRate()
-			}
-
 			return true
 		} else if x[1] == "03" { // satellite status message. Only the first 20 satellites will be reported in this message for UBX firmware older than v3.0. Order seems to be GPS, then SBAS, then GLONASS.
 
@@ -1392,10 +1388,6 @@ func processNMEALine(l string) (sentenceUsed bool) {
 			mySituation.muGPSPerformance.Unlock()
 		}
 
-		if globalSettings.IMU_Sensor_Enabled && globalStatus.IMUConnected {
-			calculateNavRate()
-		}
-
 		return true
 
 	} else if (x[0] == "GNRMC") || (x[0] == "GPRMC") { // Recommended Minimum data.
@@ -1542,10 +1534,6 @@ func processNMEALine(l string) (sentenceUsed bool) {
 				myGPSPerfStats = myGPSPerfStats[(lenGPSPerfStats - 299):] // remove the first n entries if more than 300 in the slice
 			}
 			mySituation.muGPSPerformance.Unlock()
-		}
-
-		if globalSettings.IMU_Sensor_Enabled && globalStatus.IMUConnected {
-			calculateNavRate()
 		}
 
 		setDataLogTimeWithGPS(mySituation)
@@ -1930,6 +1918,8 @@ func gpsAttitudeSender() {
 		<-timer.C
 		if !(globalStatus.GPS_connected || globalStatus.IMUConnected) {
 			myGPSPerfStats = make([]gpsPerfStats, 0) // reinitialize statistics on disconnect / reconnect
+		} else {
+			calculateNavRate()
 		}
 
 		for !(globalSettings.IMU_Sensor_Enabled && globalStatus.IMUConnected) && (globalSettings.GPS_Enabled && globalStatus.GPS_connected) {

--- a/main/gps.go
+++ b/main/gps.go
@@ -292,8 +292,8 @@ func initGPSSerial() bool {
 		if (globalStatus.GPS_detected_type == GPS_TYPE_UBX8) || (globalStatus.GPS_detected_type == GPS_TYPE_UART) { // assume that any GPS connected to serial GPIO is ublox8 (RY835/6AI)
 			//log.Printf("UBX8 device detected on USB, or GPS serial connection in use. Attempting GLONASS and Galelio configuration.\n")
 			glonass = []byte{0x06, 0x08, 0x0E, 0x00, 0x01, 0x00, 0x01, 0x01} // this enables GLONASS with 8-14 tracking channels
-			galileo = []byte{0x02, 0x04, 0x08, 0x00, 0x01, 0x00, 0x01, 0x01} // this enables Galileo with 4-8 tracking channels
-			updatespeed = []byte{0x06, 0x00, 0xF4, 0x01, 0x01, 0x00}         // Nav speed 2Hz
+			galileo = []byte{0x02, 0x04, 0x05, 0x00, 0x01, 0x00, 0x01, 0x01} // this enables Galileo with 4-5 tracking channels
+			updatespeed = []byte{0xF4, 0x01, 0x01, 0x00, 0x01, 0x00}         // Nav speed 2 Hz for enabling Galileo
 		}
 		cfgGnss = append(cfgGnss, gps...)
 		cfgGnss = append(cfgGnss, sbas...)

--- a/web/plates/gps.html
+++ b/web/plates/gps.html
@@ -110,7 +110,7 @@
 			<div class="panel-footer">
 				<div class="row">
 					<label class="col-xs-6">GPS solution:</label>
-					<span class="col-xs-6">{{SolutionText}}</span>
+					<span class="col-xs-6">{{SolutionText}} @ {{ GPS_PositionSampleRate }} Hz</span>
 				</div>
 				<div class="row">
 					<label class="col-xs-6">Summary:</label>

--- a/web/plates/js/gps.js
+++ b/web/plates/js/gps.js
@@ -105,6 +105,7 @@ function GPSCtrl($rootScope, $scope, $state, $http, $interval) {
         $scope.GPS_satellites_tracked = situation.GPSSatellitesTracked;
         $scope.GPS_satellites_seen = situation.GPSSatellitesSeen;
         $scope.Quality = situation.GPSFixQuality;
+        $scope.GPS_PositionSampleRate = situation.GPSPositionSampleRate.toFixed(1);
 
         var solutionText = "No Fix";
         if (situation.GPSFixQuality === 2) {


### PR DESCRIPTION
AHRS calculation used to be inside `calcGPSAttitude()` which is no longer being called when IMU is enabled. This PR moves the calculation code to a dedicated function to ensure nav rate can still be displayed in IMU AHRS mode to help evaluating GPS performance.

Also includes changes from #597 