### PR TITLE
Add Kwik EFIS / DMAP to apps with stratux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ Apps with stratux recognition/support:
 * Seattle Avionics FlyQ EFB 2.1.1+.
 * AvNav EFB 2.0.0+.
 * Naviator.
-* WingX Pro7 8.6.2+
+* WingX Pro7 8.6.2+.
 * FltPlan Go.
 * AerovieReports.
 * AvPlan EFB.
 * iFly GPS 9.4+.
 * DroidEFB 2.1.1+.
+* Kwik EFIS / DMAP rel 22+.
 
 
 Tested weather/traffic displays:


### PR DESCRIPTION
Kwik EFIS for Android has been upgraded to support Stratux.   
The application is released as open source and made available through F-Droid as a signed and fully FOSS compliant package.

Website: http://members.iinet.net.au/~ninelima/efis
Repository: https://github.com/ninelima/kwikEFIS

