### PR TITLE
GDL90 GPS Altitude msl vs WGS-84 ellipsoid

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -441,9 +441,16 @@ func makeOwnshipGeometricAltitudeReport() bool {
 	msg := make([]byte, 5)
 	// See p.28.
 	msg[0] = 0x0B                                // Message type "Ownship Geo Alt".
-	alt := int16(mySituation.GPSAltitudeMSL / 5) // GPS Altitude, encoded to 16-bit int using 5-foot resolution
-	msg[1] = byte(alt >> 8)                      // Altitude.
-	msg[2] = byte(alt & 0x00FF)                  // Altitude.
+
+	var GPSalt float32
+	if globalSettings.GDL90MSLAlt_Enabled {
+		GPSalt = mySituation.GPSAltitudeMSL
+	} else {
+		GPSalt = mySituation.GPSHeightAboveEllipsoid
+	}
+	encodedAlt := int16(GPSalt / 5)    // GPS Altitude, encoded to 16-bit int using 5-foot resolution
+	msg[1] = byte(encodedAlt >> 8)     // Altitude.
+	msg[2] = byte(encodedAlt & 0x00FF) // Altitude.
 
 	//TODO: "Figure of Merit". 0x7FFF "Not available".
 	msg[3] = 0x00
@@ -671,7 +678,9 @@ func makeFFIDMessage() []byte {
 	}
 	copy(msg[19:], devLongName)
 
-	msg[38] = 0x01 // Capabilities mask. MSL altitude for Ownship Geometric report.
+	if globalSettings.GDL90MSLAlt_Enabled {
+		msg[38] = 0x01 // Capabilities mask. MSL altitude for Ownship Geometric report.
+	}
 
 	return prepareMessage(msg)
 }
@@ -1116,6 +1125,7 @@ type settings struct {
 	DeveloperMode        bool
 	GLimits              string
 	StaticIps            []string
+	GDL90MSLAlt_Enabled  bool
 }
 
 type status struct {
@@ -1187,6 +1197,7 @@ func defaultSettings() {
 	globalSettings.OwnshipModeS = "F00000"
 	globalSettings.DeveloperMode = false
 	globalSettings.StaticIps = make([]string, 0)
+	globalSettings.GDL90MSLAlt_Enabled = true
 }
 
 func readSettings() {

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -364,6 +364,8 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 							continue
 						}
 						globalSettings.StaticIps = ips
+					case "GDL90MSLAlt_Enabled":
+						globalSettings.GDL90MSLAlt_Enabled = val.(bool)
 					default:
 						log.Printf("handleSettingsSetRequest:json: unrecognized key:%s\n", key)
 					}

--- a/main/traffic.go
+++ b/main/traffic.go
@@ -315,15 +315,24 @@ func makeTrafficReportMsg(ti TrafficInfo) []byte {
 	//
 	// Algo example at: https://play.golang.org/p/VXCckSdsvT
 	//
-	var alt int16
-	if ti.Alt < -1000 || ti.Alt > 101350 {
-		alt = 0x0FFF
+	// GDL90 expects barometric altitude in traffic reports
+	var baroAlt int32
+	if ti.AltIsGNSS {
+		// Convert from GPS geoid height to barometric altitude
+		baroAlt = ti.Alt - int32(mySituation.GPSGeoidSep)
+		baroAlt = baroAlt - int32(mySituation.GPSAltitudeMSL) + int32(mySituation.BaroPressureAltitude)
+	} else {
+		baroAlt = ti.Alt
+	}
+	var encodedAlt int16
+	if baroAlt < -1000 || baroAlt > 101350 {
+		encodedAlt = 0x0FFF
 	} else {
 		// output guaranteed to be between 0x0000 and 0x0FFE
-		alt = int16((ti.Alt / 25) + 40)
+		encodedAlt = int16((baroAlt / 25) + 40)
 	}
-	msg[11] = byte((alt & 0xFF0) >> 4) // Altitude.
-	msg[12] = byte((alt & 0x00F) << 4)
+	msg[11] = byte((encodedAlt & 0xFF0) >> 4) // Altitude.
+	msg[12] = byte((encodedAlt & 0x00F) << 4)
 
 	// "m" field. Lower four bits define indicator bits:
 	// - - 0 0   "tt" (msg[17]) is not valid

--- a/web/plates/gps.html
+++ b/web/plates/gps.html
@@ -21,7 +21,11 @@
 				</div>
 				<div class="row">
 					<span class="col-xs-6 text-center">{{gps_lat}}, {{gps_lon}} &plusmn; {{gps_horizontal_accuracy}} m <br>
-						{{gps_alt}} &plusmn; {{gps_vertical_accuracy}} ft  @ {{gps_vert_speed}} ft/min</span>
+						<b>Altitude MSL:</b> <br>
+						{{gps_alt}} &plusmn; {{gps_vertical_accuracy}} ft  @ {{gps_vert_speed}} ft/min <br>
+						<b>Height WGS-84 ellipsoid:</b> <br>
+						{{ gps_height_above_ellipsoid }} ft
+					</span>
 					<span class="col-xs-6 text-center">{{gps_track}}&deg; @ {{gps_speed}} KTS</span>
 				</div>
 			</div>

--- a/web/plates/js/gps.js
+++ b/web/plates/js/gps.js
@@ -144,6 +144,7 @@ function GPSCtrl($rootScope, $scope, $state, $http, $interval) {
         $scope.gps_lat = situation.GPSLatitude.toFixed(5); // result is string
         $scope.gps_lon = situation.GPSLongitude.toFixed(5); // result is string
         $scope.gps_alt = situation.GPSAltitudeMSL.toFixed(1);
+        $scope.gps_height_above_ellipsoid = situation.GPSHeightAboveEllipsoid.toFixed(1);
         $scope.gps_track = situation.GPSTrueCourse.toFixed(1);
         $scope.gps_speed = situation.GPSGroundSpeed.toFixed(1);
         $scope.gps_vert_speed = situation.GPSVerticalSpeed.toFixed(1);
@@ -151,6 +152,7 @@ function GPSCtrl($rootScope, $scope, $state, $http, $interval) {
             $scope.gps_lat = "--";
             $scope.gps_lon = "--";
             $scope.gps_alt = "--";
+            $scope.gps_height_above_ellipsoid = "--";
             $scope.gps_track = "--";
             $scope.gps_speed = "--";
             $scope.gps_vert_speed = "--";

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -7,7 +7,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 	$scope.$parent.helppage = 'plates/settings-help.html';
 
 	var toggles = ['UAT_Enabled', 'ES_Enabled', 'Ping_Enabled', 'GPS_Enabled', 'IMU_Sensor_Enabled',
-		'BMP_Sensor_Enabled', 'DisplayTrafficSource', 'DEBUG', 'ReplayLog', 'AHRSLog'];
+		'BMP_Sensor_Enabled', 'DisplayTrafficSource', 'DEBUG', 'ReplayLog', 'AHRSLog', 'GDL90MSLAlt_Enabled'];
 	var settings = {};
 	for (i = 0; i < toggles.length; i++) {
 		settings[toggles[i]] = undefined;
@@ -40,6 +40,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		$scope.OwnshipModeS = settings.OwnshipModeS;
 		$scope.DeveloperMode = settings.DeveloperMode;
         $scope.GLimits = settings.GLimits;
+        $scope.GDL90MSLAlt_Enabled = settings.GDL90MSLAlt_Enabled;
 	}
 
 	function getSettings() {

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -65,6 +65,12 @@
                             <input class="col-xs-7" type="string" required ng-model="StaticIps" ng-list=" " ng-trim="false" placeholder="space-delimited ip's to send network data" ng-blur="updatestaticips()" />
                         </form>
                 </div>
+                <div class="form-group reset-flow">
+                    <label class="control-label col-xs-5">GDL90 MSL Altitude</label>
+                    <div class="col-xs-5">
+                        <ui-switch ng-model='GDL90MSLAlt_Enabled' settings-change></ui-switch>
+                    </div>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This pull request introduces a switch to the settings page to switch between GPS altitude MSL or height above WGS-84 ellipsoid for the GDL90 ownship geometric altitude message. GDL90 specifies ownship geometric altitude as height above WGS-84 ellipsoid but some EFBs expect MSL altitude. We leave the default to MSL but allow switching to height above ellipsoid.