### PR TITLE
Fix Ownship Target Identity Information

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -295,7 +295,10 @@ func makeOwnshipReport() bool {
 	// See p.16.
 	msg[0] = 0x0A // Message type "Ownship".
 
-	msg[1] = 0x01 // Alert status, address type.
+	// Ownship Target Identify (see 3.5.1.2 of GDL-90 Specifications)
+ 	// First half of byte is 0 for 'No Traffic Alert'
+	// Second half of byte is 0 for 'ADS-B with ICAO' 
+	msg[1] = 0x00 // Alert status, address type.
 
 	code, _ := hex.DecodeString(globalSettings.OwnshipModeS)
 	if len(code) != 3 {


### PR DESCRIPTION
**Description**
The Ownship information is currently being sent with a target identity of 0x01 which represents 'No Traffic Alert' and 'ADS-B with Self Assigned Address'.  Foreflight users taking advantage of Mode S Code configuration for passing Ownship information to Foreflight for track logs and draft logbook entries, will experience Foreflight reporting no Ownship detection.  Latest Foreflight version appears to ignore Ownship information when the target identify of 0x01 is being passed.

**What Is Changing**
Update Ownship target identity to report 0x00 which represents 'No Traffic Alert' and 'ADS-B with ICAO'.  This will allow Foreflight to report Ownship Detection and list the aircraft Tail Number correctly.

**Pre-Testing**
1. Assign ICAO code in Mode S Code configuration input box
2. Open Foreflight EFB
3. Go to Devices -> Stratux
4. Verify Ownship detection reports 'Not Detected'

**Post-Testing**
1. Assign ICAO code in Mode S Code configuration input box
2. Open Foreflight EFB
3. Go to Devices -> Stratux
4. Verify Ownship detection reports correct N-Number of ICAO entry