### PR TITLE
Added setting "NoSleep" to disable sleeping

### DIFF
--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1126,6 +1126,7 @@ type settings struct {
 	WiFiSecurityEnabled  bool
 	WiFiPassphrase       string
 	WiFiSmartEnabled     bool // "Smart WiFi" - disables the default gateway for iOS.
+	NoSleep              bool
 }
 
 type status struct {
@@ -1200,6 +1201,7 @@ func defaultSettings() {
 	globalSettings.OwnshipModeS = "F00000"
 	globalSettings.DeveloperMode = false
 	globalSettings.StaticIps = make([]string, 0)
+	globalSettings.NoSleep = false
 }
 
 func readSettings() {

--- a/main/network.go
+++ b/main/network.go
@@ -145,6 +145,9 @@ func getDHCPLeases() (map[string]string, error) {
 	 ***WARNING***: netMutex must be locked before calling this function.
 */
 func isSleeping(k string) bool {
+	if globalSettings.NoSleep == true {
+		return false
+	}
 	ipAndPort := strings.Split(k, ":")
 	// No ping response. Assume disconnected/sleeping device.
 	if lastPing, ok := pingResponse[ipAndPort[0]]; !ok || stratuxClock.Since(lastPing) > (10*time.Second) {


### PR DESCRIPTION
Added a configuration parameter called "NoSleep" that disables client sleeping when enabled. This change will allow data transmission to broadcast addresses as well as clients who do not respond to a ping requests.