### PR TITLE
Add pressure altitude offset setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dump978/uat2text
 gen_gdl90
 libdump978.so
 fancontrol
+equations
 
 *.mp4
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ xgen_gdl90:
 
 fancontrol:
 	go get -t -d -v ./main
-	go build $(BUILDINFO_STATIC) -p 4 main/fancontrol.go main/equations.go main/cputemp.go
+	go build $(BUILDINFO_STATIC) -p 4 -o fancontrol main/fancontrol.go main/equations.go main/cputemp.go
 
 xdump1090:
 	git submodule update --init

--- a/godump978/godump978_exports.go
+++ b/godump978/godump978_exports.go
@@ -14,7 +14,7 @@ import (
 )
  
 /*
-#cgo CFLAGS: -L../
+#cgo CFLAGS: -I../
 
 #include <stdint.h>
 #include "../dump978/dump978.h"

--- a/main/equations.go
+++ b/main/equations.go
@@ -334,8 +334,8 @@ func distance(lat1, lon1, lat2, lon2 float64) (dist, bearing float64) {
 }
 
 // CalcAltitude determines the pressure altitude (feet) from the atmospheric pressure (hPa)
-func CalcAltitude(press float64) (altitude float64) {
-	altitude = 145366.45 * (1.0 - math.Pow(press/1013.25, 0.190284))
+func CalcAltitude(press float64, altoffset int) (altitude float64) {
+	altitude = 145366.45 * (1.0 - math.Pow(press/1013.25, 0.190284)) + float64(altoffset)
 	return
 }
 

--- a/main/gen_gdl90.go
+++ b/main/gen_gdl90.go
@@ -1120,6 +1120,7 @@ type settings struct {
 	SensorQuaternion     [4]float64 // Quaternion mapping from sensor frame to aircraft frame
 	C, D                 [3]float64 // IMU Accel, Gyro zero bias
 	PPM                  int
+	AltitudeOffset       int
 	OwnshipModeS         string
 	WatchList            string
 	DeveloperMode        bool

--- a/main/managementinterface.go
+++ b/main/managementinterface.go
@@ -312,6 +312,8 @@ func handleSettingsSetRequest(w http.ResponseWriter, r *http.Request) {
 						}
 					case "PPM":
 						globalSettings.PPM = int(val.(float64))
+					case "AltitudeOffset":
+						globalSettings.AltitudeOffset = int(val.(float64))
 					case "Baud":
 						if serialOut, ok := globalSettings.SerialOutputs["/dev/serialout0"]; ok { //FIXME: Only one device for now.
 							newBaud := int(val.(float64))

--- a/main/sensors.go
+++ b/main/sensors.go
@@ -114,7 +114,7 @@ func tempAndPressureSender() {
 		mySituation.muBaro.Lock()
 		mySituation.BaroLastMeasurementTime = stratuxClock.Time
 		mySituation.BaroTemperature = float32(temp)
-		altitude = CalcAltitude(press)
+		altitude = CalcAltitude(press,globalSettings.AltitudeOffset)
 		mySituation.BaroPressureAltitude = float32(altitude)
 		if altLast < -2000 {
 			altLast = altitude // Initialize

--- a/notes/app-vendor-integration.md
+++ b/notes/app-vendor-integration.md
@@ -198,6 +198,7 @@ Stratux makes available a webserver to retrieve statistics which may be useful t
     -1.890621662038
   ],
   "PPM": 0,
+  "AltitudeOffset": 0,
   "OwnshipModeS": "F00000",
   "WatchList": "",
   "DeveloperMode": false,

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -171,6 +171,20 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		}
 	};
 
+	$scope.updatealtitudeoffset = function () {
+		settings["AltitudeOffset"] = 0;
+		if (($scope.AltitudeOffset !== undefined) && ($scope.AltitudeOffset !== null) && ($scope.AltitudeOffset !== settings["AltitudeOffset"])) {
+			settings["AltitudeOffset"] = parseInt($scope.AltitudeOffset);
+			var newsettings = {
+				"AltitudeOffset": settings["AltitudeOffset"]
+			};
+			// console.log(angular.toJson(newsettings));
+			setSettings(angular.toJson(newsettings));
+		}
+	};
+
+
+
     $scope.updateGLimits = function () {
         if ($scope.GLimits !== settings["GLimits"]) {
             settings["GLimits"] = $scope.GLimits;

--- a/web/plates/js/settings.js
+++ b/web/plates/js/settings.js
@@ -40,6 +40,7 @@ function SettingsCtrl($rootScope, $scope, $state, $location, $window, $http) {
 		$scope.AHRSLog = settings.AHRSLog;
 
 		$scope.PPM = settings.PPM;
+		$scope.AltitudeOffset = settings.AltitudeOffset;
 		$scope.WatchList = settings.WatchList;
 		$scope.OwnshipModeS = settings.OwnshipModeS;
 		$scope.DeveloperMode = settings.DeveloperMode;

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -118,6 +118,15 @@
                                    ng-blur="updatestaticips()" />
                         </form>
                     </div>
+                    <div class="form-group reset-flow">
+                        <label class="control-label col-xs-5">P-Altitude Offset</label>
+                        <form name="altForm" ng-submit="updatealtitudeoffset()" novalidate>
+                            <!-- type="number" not supported except on mobile -->
+                            <input class="col-xs-7" type="number" ng-model="Altitude Offset" placeholder="integer"
+                                   ng-blur="updatealtitudeoffset()" />
+                        </form>
+                    </div>
+
                 </div>
             </div>
         </div>

--- a/web/plates/settings.html
+++ b/web/plates/settings.html
@@ -122,7 +122,7 @@
                         <label class="control-label col-xs-5">P-Altitude Offset</label>
                         <form name="altForm" ng-submit="updatealtitudeoffset()" novalidate>
                             <!-- type="number" not supported except on mobile -->
-                            <input class="col-xs-7" type="number" ng-model="Altitude Offset" placeholder="integer"
+                            <input class="col-xs-7" type="number" ng-model="AltitudeOffset" placeholder="integer"
                                    ng-blur="updatealtitudeoffset()" />
                         </form>
                     </div>


### PR DESCRIPTION
A new setting allows adjustment of the pressure altitude if the sensor is not reporting it correctly (manufacturing variance?).  In the Settings web UI simply add a positive or negative offset in feet to match the aircraft's pressure altitude (i.e. the altimeter reading when set to 29.92 inHg)

![image](https://user-images.githubusercontent.com/9923389/101495832-041e2100-3937-11eb-86ca-b50e4191656e.png)
